### PR TITLE
Fix: Remove unused eslint-disable directive

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,6 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();


### PR DESCRIPTION
## Summary
Fixes a code smell by removing an unnecessary ESLint disable directive.

## Changes
- Removed unused `// eslint-disable-next-line no-await-in-loop` comment from `vendor/nodebb-theme-harmony-2.1.15/library.js`
- The `no-await-in-loop` rule was not being triggered, making the directive dead code

## Type of Code Smell Fixed
**Dead Code / Unused Code** - The ESLint disable directive was not serving any purpose and was creating maintenance overhead.

## Testing
- ✅ ESLint linting passes without warnings
- ✅ No functionality changes - only removed dead code

## Impact
- Improves code clarity
- Reduces maintenance overhead  
- Eliminates misleading comments