### PR TITLE
refactor(mods): extract isOnlyPagination helper to fix complex binary

### DIFF
--- a/src/controllers/mods.js
+++ b/src/controllers/mods.js
@@ -69,10 +69,15 @@ modsController.flags.list = async function (req, res) {
 	}
 
 	// Pagination doesn't count as a filter
-	if (
-		(Object.keys(filters).length === 1 && filters.hasOwnProperty('page')) ||
-		(Object.keys(filters).length === 2 && filters.hasOwnProperty('page') && filters.hasOwnProperty('perPage'))
-	) {
+	const isOnlyPagination = (filtersObj) => {
+		const keys = Object.keys(filtersObj);
+		const hasPage = Object.prototype.hasOwnProperty.call(filtersObj, 'page');
+		const hasPerPage = Object.prototype.hasOwnProperty.call(filtersObj, 'perPage');
+
+		return (keys.length === 1 && hasPage) || (keys.length === 2 && hasPage && hasPerPage);
+	};
+
+	if (isOnlyPagination(filters)) {
 		hasFilter = false;
 	}
 


### PR DESCRIPTION
I fixed a Qlty "Complex binary expression" smell in [mods.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/) by extracting a small local helper, [isOnlyPagination(filtersObj)](https://zany-enigma-6999xjjx549qc54qp.github.dev/), which replaces the previous inline multi-clause condition that checked whether the [filters](https://zany-enigma-6999xjjx549qc54qp.github.dev/) object contained only pagination keys ([page](https://zany-enigma-6999xjjx549qc54qp.github.dev/), optionally perPage); the refactor preserves existing behavior, improves readability and maintainability, and was committed on branch andrewx/task-1 with message "refactor(mods): extract isOnlyPagination helper to fix complex binary expression code smell"; I ran ESLint (no errors, one unrelated vendor warning) and ran a focused test subset (6 passing, 2 failing tests that appear unrelated to this change), and I attempted to run qlty via npx but the package is not available from the npm registry—happy to add a unit test for the new helper or include the Qlty output if you run qlty smells --all --no-snippets locally and paste it here.