### PR TITLE
Refactor (src/upgrades/1.15.0/add_target_uid_to_flags.js): flatten control flow and remove await inside loop

### DIFF
--- a/src/upgrades/1.15.0/add_target_uid_to_flags.js
+++ b/src/upgrades/1.15.0/add_target_uid_to_flags.js
@@ -10,28 +10,38 @@ module.exports = {
 	method: async function () {
 		const { progress } = this;
 
-		await batch.processSortedSet('flags:datetime', async (flagIds) => {
-			progress.incr(flagIds.length);
-			const flagData = await db.getObjects(flagIds.map(id => `flag:${id}`));
-			for (const flagObj of flagData) {
-				/* eslint-disable no-await-in-loop */
-				if (flagObj) {
-					const { targetId } = flagObj;
-					if (targetId) {
-						if (flagObj.type === 'post') {
+		await batch.processSortedSet(
+			'flags:datetime',
+			async (flagIds) => {
+				progress.incr(flagIds.length);
+				const flagData = await db.getObjects(
+					flagIds.map(id => `flag:${id}`)
+				);
+
+				// Collect async operations
+				const ops = flagData
+					.filter(flagObj => flagObj && flagObj.targetId)
+					.map(async (flagObj) => {
+						const { targetId, type, flagId } = flagObj;
+
+						if (type === 'post') {
 							const targetUid = await posts.getPostField(targetId, 'uid');
-							if (targetUid) {
-								await db.setObjectField(`flag:${flagObj.flagId}`, 'targetUid', targetUid);
-							}
-						} else if (flagObj.type === 'user') {
-							await db.setObjectField(`flag:${flagObj.flagId}`, 'targetUid', targetId);
+							if (!targetUid) return;
+							return db.setObjectField(`flag:${flagId}`, 'targetUid', targetUid);
 						}
-					}
-				}
+
+						if (type === 'user') {
+							return db.setObjectField(`flag:${flagId}`, 'targetUid', targetId);
+						}
+					});
+
+				// Run all in parallel
+				await Promise.all(ops);
+			},
+			{
+				progress,
+				batch: 500,
 			}
-		}, {
-			progress: progress,
-			batch: 500,
-		});
+		);
 	},
 };


### PR DESCRIPTION
This PR improves the add_target_uid_to_flags upgrade script by reducing complexity and addressing performance issues:
	•	Replaced deeply nested if statements with guard clauses for clearer logic.
	•	Removed await calls inside the loop by collecting async operations and resolving them with Promise.all.
	•	Improved readability with variable destructuring and simplified branching.
	•	Ensures flag objects of type post and user are still handled correctly while executing updates concurrently.

These changes make the code easier to maintain, eliminate ESLint’s no-await-in-loop warning, and improve execution efficiency when processing large batches of flags.