### PR TITLE
Refactor getTopicsFromSet to use object parameter and update its usages

### DIFF
--- a/src/controllers/accounts/posts.js
+++ b/src/controllers/accounts/posts.js
@@ -107,7 +107,7 @@ const templateToData = {
 			};
 
 			if (!sort || !map[sort]) {
-				return await topics.getTopicsFromSet(set, req.uid, start, stop);
+				return await topics.getTopicsFromSet({ set, uid: req.uid, start, stop });
 			}
 			const sortSet = map[sort];
 			let tids = await db.getSortedSetRevRange(set, 0, -1);

--- a/src/routes/feeds.js
+++ b/src/routes/feeds.js
@@ -242,7 +242,7 @@ async function generateSorted(options, req, res, next) {
 async function sendTopicsFeed(options, set, res, timestampField) {
 	const start = options.hasOwnProperty('start') ? options.start : 0;
 	const stop = options.hasOwnProperty('stop') ? options.stop : 19;
-	const topicData = await topics.getTopicsFromSet(set, options.uid, start, stop);
+	const topicData = await topics.getTopicsFromSet({ set, uid: options.uid, start, stop });
 	const feed = await generateTopicsFeed(options, topicData.topics, timestampField);
 	sendFeed(feed, res);
 }

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -42,7 +42,7 @@ Topics.exists = async function (tids) {
 	);
 };
 
-Topics.getTopicsFromSet = async function (set, uid, start, stop) {
+Topics.getTopicsFromSet = async function ({ set, uid, start, stop }) {
 	const tids = await db.getSortedSetRevRange(set, start, stop);
 	const topics = await Topics.getTopics(tids, uid);
 	Topics.calculateTopicIndices(topics, start);


### PR DESCRIPTION
I used GPT-4o to resolve the following smell in src/topics/index.js. 
Code smell: Function with many parameters (count = 4): getTopicsFromSet

*The following description was written by GPT-4o*

Summary:
This pull request refactors the [getTopicsFromSet] function to address the code smell of having too many parameters. The function now accepts a single object parameter, improving readability and maintainability. All usages of the function have been updated accordingly.

Changes Made:
Refactored [getTopicsFromSet] in [index.js] to use an object parameter.
Updated calls to in: [posts.js], [feeds.js]

Testing:
Verified that the application compiles without errors. Ensured all references to [getTopicsFromSet] were updated and tested.

Notes:
This change improves the code's maintainability and aligns with best practices for managing function parameters.