### PR TITLE
Refactor(widgets): reduce function parameter count

### DIFF
--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -27,7 +27,9 @@ widgets.render = async function (uid, options) {
 		config = await apiController.loadConfig(options.req);
 	}
 
-	const widgetData = await Promise.all(locations.map(location => renderLocation(location, data, uid, options, config)));
+	const widgetData = await Promise.all(
+		locations.map(location => renderLocation(location, data, { uid, options, config }))
+	);
 
 	const returnData = {};
 	locations.forEach((location, i) => {
@@ -39,7 +41,8 @@ widgets.render = async function (uid, options) {
 	return returnData;
 };
 
-async function renderLocation(location, data, uid, options, config) {
+async function renderLocation(location, data, context) {
+	const { uid, options, config } = context;
 	const widgetsAtLocation = (data[options.template][location] || []).concat(data.global[location] || []);
 
 	if (!widgetsAtLocation.length) {
@@ -47,12 +50,13 @@ async function renderLocation(location, data, uid, options, config) {
 	}
 
 	const renderedWidgets = await Promise.all(
-		widgetsAtLocation.map(widget => renderWidget(widget, uid, options, config, location))
+		widgetsAtLocation.map(widget => renderWidget(widget, { uid, options, config, location }))
 	);
 	return renderedWidgets;
 }
 
-async function renderWidget(widget, uid, options, config, location) {
+async function renderWidget(widget, ctx) {
+	const { uid, options, config, location } = ctx;
 	if (!widget || !widget.data || (!!widget.data['hide-mobile'] && options.req.useragent.isMobile)) {
 		return;
 	}


### PR DESCRIPTION
Summary\nCollapse renderLocation and renderWidget parameters into a single context object.\n\nMotivation\nReduce functions with many parameters (code smell) for clearer signatures and easier future refactors.\n\nChanges\n- src/widgets/index.js: refactor renderLocation/renderWidget to accept context object; updated call sites.\n\nHow to test\n- npm run lint\n- node -e "require('./src/widgets/index.js')"\n\nNotes\nLow-risk change; file still has high overall complexity and can be addressed in follow-up PRs.


Chatlog:

kaylae605: can you help me fix this code smell 
src/widgets/index.js
    Function with many parameters (count = 5): renderLocation

^[]11;rgb:0101/0404/0909^[\          42  async function renderLocation(location, data, uid, options, config) {

    Function with many parameters (count = 5): renderWidget

          55  async function renderWidget(widget, uid, options, config, location) {

    High total complexity (count = 59)

           1  'use strict';
           2  
           3  const winston = require('winston');
           4  const _ = require('lodash');
           5  const Benchpress = require('benchpressjs');
           6  
              [hid 308 additional lines]

GitHub Copilot: Enable GPT-5 mini for all clients
[object Object]

kaylae605: @agent Enable: "Enable GPT-5 mini for all clients"

GitHub Copilot: I'll read the index.js file to inspect `renderLocation` and `renderWidget`, so I can propose and implement a focused refactor (collapse parameters into an options object and extract helpers). I'll read a large chunk of the file to get full context. 

Read [](file:///workspaces/NodeBB.ai/src/widgets/index.js)

I'll update index.js to collapse the 5 parameters into a single context object and adjust call sites. This reduces parameter count for `renderLocation` and `renderWidget` and keeps behavior unchanged. I'll apply the patch now. 

Using "Apply Patch"


```

```
I've refactored the two functions to accept a single context object and updated the call site in `widgets.render`. Next I'll run a quick lint/type check to ensure no syntax errors. I'll run `node -c` isn't a thing for JS; I'll run `node` to attempt requiring the module to catch syntax errors by running a small node script that requires the file. I'll run it in the terminal. 

Ran terminal command: node -e "require('./src/widgets/index.js'); console.log('widgets module loaded')"

The module loaded but Winston logged a message about no transports (not an error). No syntax errors. I'll run the project's test script (if any) or run eslint to check complexity warnings might still exist; but the primary code smell is fixed by reducing parameter count. I'll run eslint on the file to check for issues. 

Ran terminal command: npx eslint src/widgets/index.js --max-warnings=0 || true

I'll read the top portion of the file again to find the long line and confirm locations. 

Read [](file:///workspaces/NodeBB.ai/src/widgets/index.js#1-1), lines 1 to 120

I'll update the long line to conform to max line length by breaking the Promise.all call into multiple lines. Then I'll re-run ESLint to confirm no remaining lint errors. 

Using "Apply Patch"


```

```


Ran terminal command: npx eslint src/widgets/index.js --max-warnings=0 || true

Read [](file:///workspaces/NodeBB.ai/package.json)

I'll refactor `renderLocation` and `renderWidget` to remove the large parameter lists and verify the change (syntax + lint). Below is what I changed, why, verification results, and suggested next steps.

## What I changed
- Collapsed the 5-parameter signatures into a single "context" object for both functions:
  - renderLocation(location, data, context) — context = { uid, options, config }
  - renderWidget(widget, ctx) — ctx = { uid, options, config, location }
- Updated the call site in `widgets.render` and the internal mapping so callers pass a single object.
- Wrapped a long line to satisfy the repo's `max-len` lint rule.

Files edited
- index.js — refactor `renderLocation` and `renderWidget` to use a single context object and adjusted call sites.

This directly addresses the "Function with many parameters (count = 5)" code smell you reported for `renderLocation` and `renderWidget`.

## Key diffs (high level)
- widgets.render: locations.map(...) now calls renderLocation(location, data, { uid, options, config })
- renderLocation: destructures context to { uid, options, config } and maps to renderWidget(widget, { uid, options, config, location })
- renderWidget: now receives a single ctx and destructures it

(Edits were applied directly to the file in the workspace.)

## Quick verification (done)
- Required the module to check for syntax/load errors:
  - Node loaded the module successfully. (Note: Winston emitted a "no transports" info message — not a syntax or runtime error.)
- Ran ESLint on the file:
  - No remaining lint errors from the edits (the only console output was a deprecation notice from an eslint plugin; not an error).
  - A prior `max-len` complaint was fixed by breaking the long line.

Commands I ran (for reproducibility)
- Require module (syntax check):
  ```bash
  node -e "require('./src/widgets/index.js'); console.log('widgets module loaded')"
  ```
- ESLint check:
  ```bash
  npx eslint src/widgets/index.js --max-warnings=0
  ```

## Requirements coverage
- Reduce parameter count for `renderLocation`: Done.
- Reduce parameter count for `renderWidget`: Done.
- High total complexity of file: Deferred — I did not restructure the whole file to reduce overall cyclomatic complexity (the file is still large/complex). I kept the change minimal/risk-limited. I can follow up with a deeper refactor to split responsibilities and reduce complexity if you want.

## Edge cases & notes
- This refactor is internal and non-breaking for external callers because `renderLocation` and `renderWidget` are internal functions (not exported). If any other code in the repo required those exact signatures (unlikely here), the change would need a compatibility shim.
- Behavior is unchanged: all original properties (uid, options, config, location) are passed through as before.
- The Winston message on require is expected in this environment because Winston may be configured without transports during tests; it's informational.

## Suggested next steps (I can implement)
1. Reduce file complexity:
   - Extract widget rendering logic (the large try/catch block that compiles container, translates HTML, etc.) into a small helper like `renderWidgetHtml(widget, data, config)` to reduce the cognitive load and cyclomatic complexity of `renderWidget`.
   - Move widget data parsing and area-management to separate modules (`src/widgets/renderer.js`, `src/widgets/data.js`), leaving a lean public API in index.js.
2. Add unit tests:
   - Add focused unit tests for `renderWidget` behavior (visibility checks, mobile hide, translation path, container wrapping).
3. Add a small refactor commit to reduce cyclomatic complexity (I can split functions and run tests/linter after).
4. If you want, I can proceed to perform the deeper refactor (split file + add tests). I estimate 2–3 small files and 1–3 tests; I will run lint and the test suite after changes.

Would you like me to:
- A) stop here (the parameter-count smell is fixed), or
- B) continue and do the deeper refactor to lower total complexity (I'll extract helpers and add tests)?

Pick A or B and I’ll continue.

Made changes.

kaylae605: are you done

GitHub Copilot: I finished the focused refactor to fix the “many parameters” smell — here’s the short status and next choices.

What I did (done)
- Refactored signatures to use a single context object:
  - `renderLocation(location, data, context)` — context = { uid, options, config }
  - `renderWidget(widget, ctx)` — ctx = { uid, options, config, location }
- Updated call sites in `widgets.render` and inside `renderLocation`.
- Fixed a long line to satisfy the repo max-len lint rule.
- Files edited: index.js
- Verified: module requires cleanly (no syntax error) and ESLint shows no errors from the change.

What remains (not changed)
- The file is still large and has high overall complexity (cyclomatic complexity remains high). I intentionally kept the change small and low-risk. If you want, I can continue and perform a deeper refactor to split responsibilities and lower total complexity.

Next options — pick one
- A) Stop here (done) — keep changes as-is.
- B) Continue: I will reduce total complexity by extracting helpers (for example, move HTML/container rendering and translate logic into a helper `renderWidgetHtml`) and add a couple of unit tests. I estimate 2–3 small files/edits + tests and I will run lint/tests after.

Tell me A or B and I’ll proceed. If B, I’ll outline the small refactor plan and apply it.

kaylae605: well as of right now, did the changes you make remove the code smell

GitHub Copilot: Short answer: partially — yes for the "many parameters" smell, no for the overall complexity.

What I changed (delta)
- Fixed the two functions flagged for many parameters:
  - `renderLocation` now accepts (location, data, context) where context = { uid, options, config } — DONE.
  - `renderWidget` now accepts (widget, ctx) where ctx = { uid, options, config, location } — DONE.
- Verified the module loads and ran ESLint on index.js — no lint errors from these edits.

What remains
- High total complexity (count = 59): NOT fixed. The file is still large and has many responsibilities (data fetching/parsing, area management, visibility checks, rendering, translation, persistence). The small, low-risk refactor I applied intentionally avoided reorganizing responsibilities to keep change minimal.

Evidence
- Module require: succeeded (no syntax/runtime load errors).
- ESLint run on the file: no errors after the edits (I resolved a max-len issue while editing).

Recommended next steps to remove the complexity code smell
- Extract a focused helper for HTML rendering and translation (e.g., `renderWidgetHtml(widget, data, config)`), moving the try/catch and Benchpress/translator logic out of `renderWidget`.
- Split index.js into smaller modules:
  - `src/widgets/renderer.js` (rendering/translation)
  - `src/widgets/data.js` (parsing, get/set area)
  - keep index.js as the public API that composes those modules.
- Add unit tests for the rendering helper and visibility checks.
- Re-run complexity/lint reports to confirm the count drops.

If you'd like, I can proceed with that deeper refactor now (I estimate 2–3 new small files, 1–3 tests). Do you want me to continue?

kaylae605: yeah that's fine i dont need any other changes

GitHub Copilot: Great — I'll stop here.

Summary of what I changed
- Reduced parameter count by refactoring:
  - `renderLocation(location, data, context)` — context = { uid, options, config }
  - `renderWidget(widget, ctx)` — ctx = { uid, options, config, location }
- Updated call-sites in `widgets.render`.
- Fixed one long line to satisfy `max-len`.
- File edited: index.js

Quick verification performed
- Required the module to check for syntax/load errors — module loaded successfully.
- Ran ESLint on index.js — no lint errors from the edits.

If you want later
- I can split the file or add tests to address the remaining complexity.
- I can open a small PR with these changes and a brief commit message if you'd like.

If there's nothing else, you're all set.

kaylae605: how do I submit a pull request with the changes

GitHub Copilot: I'll walk you through a safe, repeatable sequence to push your changes and open a pull request (web or CLI), plus a suggested PR template and quick checks to run first.

Quick checklist (what you'll do)
- Verify changes and run lint/tests
- Commit your edits on a branch
- Push the branch to the remote (your fork or origin)
- Open a Pull Request targeting `main` (via web or GitHub CLI)

Commands to run (bash)

1) Verify local status and run lint/tests
```bash
# show what will be committed
git status

# run the project's lint and tests (optional but recommended)
npm run lint
npm test
```

2) Stage and commit your changes
- If you already committed on `kaylae/task-1` you can skip these steps. Otherwise:
```bash
# stage all changes
git add -A

# make a clear commit (use your own message if you prefer)
git commit -m "Refactor(widgets): collapse renderLocation/renderWidget params into context object"
```

3) Confirm your current branch and remotes
```bash
# show current branch
git branch --show-current

# show configured remotes
git remote -v
```
- If your current branch is `kaylae/task-1` and `origin` is set to the fork/remote you want to push to, continue.
- If you need to create a new branch instead:
```bash
git checkout -b feat/refactor-widgets-context
# then commit if not already committed
git add -A
git commit -m "Refactor(widgets): collapse renderLocation/renderWidget params into context object"
```

4) Push the branch to the remote
```bash
# push current branch and set upstream
git push -u origin kaylae/task-1
# OR if you created a new branch
git push -u origin feat/refactor-widgets-context
```
- If `origin` points to the upstream repo (not your fork) and you want to push to your fork, add your fork as `origin` or add a new remote (e.g. `myfork`) and push to it:
```bash
git remote add myfork git@github.com:<your-github-username>/NodeBB.ai.git
git push -u myfork feat/refactor-widgets-context
```

5) Open the Pull Request
Option A — Web (easy)
- Go to your repository on GitHub (your fork). You’ll usually see a "Compare & pull request" banner for the branch you just pushed. Click that.
- Target branch: base = `main`, compare = your branch (e.g., `kaylae/task-1`).
- Fill title and description and create the PR.

Option B — GitHub CLI (if you have `gh` installed)
```bash
# from your branch
gh pr create --base main --head <your-username>:kaylae/task-1 \
  --title "Refactor: reduce params in widget rendering" \
  --body "Short summary of the change and why.\n\nChanges:\n- collapsed parameters for renderLocation and renderWidget\n- updated call sites and fixed lint max-len\n\nVerification:\n- module loads; eslint run; manual smoke tested."
```
- If you pushed a different branch replace `kaylae/task-1` accordingly.

PR description template (copy into PR body)
- Summary: One-line summary of the change.
- Motivation: Why this change was made (code-smell reduction, readability).
- Changes: Bullet list of important changed files & responsibilities.
- How to test: Steps to verify locally (e.g., run lint, load module).
- Notes: Anything reviewers should pay attention to (possible follow-ups, complexity still high but out of scope).

Example:
```
Summary
Refactor: collapse renderLocation/renderWidget parameters into a single context object.

Motivation
Reduce functions with many parameters (code smell) for clearer signatures and easier future refactoring.

Changes
- src/widgets/index.js: renderLocation and renderWidget now accept context objects; updated call sites.

How to test
- npm run lint
- node -e "require('./src/widgets/index.js')"

Notes
This is a low-risk refactor; file complexity still high and may be addressed in a follow-up.
```

Optional: I can open the PR for you
- If you want, I can run the push and `gh pr create` for you here — tell me which branch to push and whether to use the web or CLI PR flow.

kaylae605: yeah can you open it

GitHub Copilot: I'll push your branch and open a PR: I'll check git status/branch, commit any unstaged changes, push the branch to origin, then create a PR with the GitHub CLI (falling back to instructions if GH CLI isn't available). Expected outcome: branch pushed and PR created (or clear fallback if gh not available). I'll run the commands now. 

Ran terminal command: git status --porcelain; git rev-parse --abbrev-ref HEAD; git remote -v

I'll commit the unstaged change, push your branch to `origin`, then try to open a PR with the GitHub CLI. Expected outcome: branch pushed and PR created (if `gh` is installed and authenticated); otherwise I'll show the web-UI link and failure details. 

Ran terminal command: git add src/widgets/index.js && git commit -m "Refactor(widgets): collapse renderLocation/renderWidget params into context object" || echo 'No changes to commit' && git push -u origin kaylae/task-1

I'll attempt to create a pull request using the GitHub CLI (`gh`). If it's not available or not authenticated, I'll fall back to printing the URL for the PR compare page. 

Ran terminal command: gh pr create --base main --head CMU-313:kaylae/task-1 --title "Refactor(widgets): reduce function parameter count" --body "Collapse renderLocation and renderWidget parameters into context objects to address a code-smell for functions with many parameters.\n\nVerification: module loads and eslint run on file." || true

Progress update — branch pushed and PR open step attempted.

What I did
- Staged and committed the change:
  - Commit: Refactor(widgets): collapse renderLocation/renderWidget params into context object
- Pushed branch `kaylae/task-1` to `origin` (https://github.com/CMU-313/NodeBB.ai).
- Attempted to create a PR via the GitHub CLI, but `gh` is not installed in the container (bash: gh: command not found).

What I need from you (two easy options)
- A) I can open the PR for you if you want me to use the web UI: I'll give you the compare URL — open it in your browser and click "Create pull request".
- B) If you prefer I use the CLI here, install & authenticate `gh` in the environment, then tell me and I'll run the `gh pr create` command. (I can show commands to install and authenticate.)

PR details you can create via web (copy into the browser)
- Base: main
- Compare: kaylae/task-1
- Title: Refactor(widgets): reduce function parameter count
- Body:
  Summary
  Collapse renderLocation and renderWidget parameters into a single context object.

  Motivation
  Reduce functions with many parameters (code smell) for clearer signatures.

  Changes
  - src/widgets/index.js: refactor renderLocation/renderWidget to accept context object; updated call sites.

  How to test
  - npm run lint
  - node -e "require('./src/widgets/index.js')"

Direct compare URL (open this in your browser)
- If your remote is https://github.com/CMU-313/NodeBB.ai and branch is pushed, use:
  https://github.com/CMU-313/NodeBB.ai/compare/main...kaylae/task-1

Next steps — choose one
- Reply "Open PR" and I'll print a ready-to-click compare URL and suggested PR body (done above), or
- Reply "Install gh" and I'll show commands to install & authenticate `gh` then create the PR from the container.

kaylae605: Open PR

GitHub Copilot: I'll try to create the pull request using the GitHub CLI; if that fails (not installed or not authenticated) I'll fall back to giving you a ready-to-open compare URL and PR body. 

Ran terminal command: gh pr create --base main --head kaylae/task-1 --title "Refactor(widgets): reduce function parameter count" --body "Collapse renderLocation and renderWidget parameters into context objects to address a code-smell for functions with many parameters.\n\nVerification: module loads and eslint run on file."

I tried to open the PR automatically but `gh` isn't installed in the environment (bash: gh: command not found). I pushed your branch already, so creating the PR is a single click in the browser.

Open this compare page to create the PR:
https://github.com/CMU-313/NodeBB.ai/compare/main...kaylae/task-1

Suggested PR title and body (copy/paste into the GitHub UI)

Title
Refactor(widgets): reduce function parameter count

Body
Summary
Collapse renderLocation and renderWidget parameters into a single context object.

Motivation
Reduce functions with many parameters (code smell) for clearer signatures and easier future refactors.

Changes
- src/widgets/index.js: refactor renderLocation/renderWidget to accept context object; updated call sites.

How to test
- npm run lint
- node -e "require('./src/widgets/index.js')"

Notes
Low-risk change; file still has high overall complexity and can be addressed in follow-up PRs.

If you want, I can:
- Install and use `gh` here to open the PR programmatically (I can show the commands to install and authenticate), or
- Create the PR description and title for you and open it from your browser if you prefer.

kaylae605: yeah do that

GitHub Copilot: I'll install the GitHub CLI in the container and check authentication status so I can create the PR programmatically; expected outcome: `gh` installed and either authenticated (then I'll create the PR) or unauthenticated (I'll show the auth steps and then create the PR once you provide authorization). 

Ran terminal command: sudo apt-get update && sudo apt-get install -y gh

Ran terminal command: gh auth status || gh auth login

gh is installed and authenticated as kaylae605. I'll create the PR now. 

Ran terminal command: gh pr create --base main --head kaylae/task-1 --title "Refactor(widgets): reduce function parameter count" --body "Summary\nCollapse renderLocation and renderWidget parameters into a single context object.\n\nMotivation\nReduce functions with many parameters (code smell) for clearer signatures and easier future refactors.\n\nChanges\n- src/widgets/index.js: refactor renderLocation/renderWidget to accept context object; updated call sites.\n\nHow to test\n- npm run lint\n- node -e \"require('./src/widgets/index.js')\"\n\nNotes\nLow-risk change; file still has high overall complexity and can be addressed in follow-up PRs."

Done — PR created.

- URL: https://github.com/CMU-313/NodeBB.ai/pull/34

What I did
- Installed GitHub CLI in the container.
- Verified authentication (logged in as kaylae605).
- Created the PR from branch `kaylae/task-1` into `main` with a descriptive title and body.

Next (optional)
- I can add reviewers or labels to the PR if you want.
- I can squash/modify the commit or add additional commits to the branch before merging.
- I can open the PR description in your browser if you'd like me to.

kaylae605: can you verify the changes you made

GitHub Copilot: I'll run three checks: show the last commit metadata, require the module to ensure it loads, and run the project's full lint script. Expected outcome: commit shows the change, module loads without syntax errors, and lint passes (or reports issues). I'll run them now. 

Ran terminal command: git show --name-only HEAD --pretty=format:"%h %s%n%b"

Ran terminal command: node -e "require('./src/widgets/index.js'); console.log('module requires OK')"

Ran terminal command: npm run lint --silent || true

I'll verify what changed and run quick checks — summary below.

What I verified
- Latest commit: 7bf0de8 — "Refactor(widgets): collapse renderLocation/renderWidget params into context object"
  - File changed: index.js
- Module load: Requiring index.js succeeded (no syntax errors). Winston emitted a benign log about transports.
- Lint: Ran the project's `npm run lint`. Lint completed with a single warning in a vendor file (library.js) (unused eslint-disable directive). There are no lint errors related to our edited file.

Concrete outputs
- git show HEAD:
  - 7bf0de8 Refactor(widgets): collapse renderLocation/renderWidget params into context object
  - index.js
- node require:
  - Printed Winston message (informational) and no crash.
- npm run lint:
  - 1 warning in vendor file; no errors.

Conclusion
- The changes I made are committed and pushed to your branch.
- The updated file loads without syntax/runtime load errors.
- The repository lint run shows only an unrelated warning in vendor code; our changes caused no lint errors.

If you'd like, I can:
- Run a focused ESLint on index.js only (already ran earlier and it passed).
- Add a small unit test for `renderLocation`/`renderWidget` behavior (visibility, mobile hide).
- Add the PR reviewers/labels or merge the PR if ready. Which would you like next?

kaylae605: can you run a focused ESLint

GitHub Copilot: I'll run ESLint just on index.js to show any errors or warnings for that file only; expected outcome: lint output (errors/warnings) or confirmation it's clean. I'll run ESLint now. 

Ran terminal command: npx eslint src/widgets/index.js --max-warnings=0 || true

I'll summarize the focused ESLint run I just performed on the file.

## What I ran
- Command:
```bash
npx eslint src/widgets/index.js --max-warnings=0 || true
```

## Result
- No ESLint errors or warnings were reported for index.js.
- The only console output was a deprecation notice from an eslint plugin:
  - "[@stylistic/eslint-plugin-js] This package is deprecated ..."

## Conclusion
- The edits to index.js (collapsing parameters into a context object and the small formatting change) passed the focused ESLint check.
- If you want, I can:
  - Auto-fix minor issues with `--fix` across the repo or for this file.
  - Run a full repo lint again and optionally suppress that plugin notice by updating devDeps (larger change).
  - Add a small unit test for `renderLocation`/`renderWidget`.

Which of those would you like next, if any?