### PR TITLE
mongo: use winston.warn for E11000 duplicate-key retries

### DIFF
--- a/src/database/mongo/hash.js
+++ b/src/database/mongo/hash.js
@@ -2,6 +2,7 @@
 
 module.exports = function (module) {
 	const helpers = require('./helpers');
+	const winston = require('winston');
 
 	const cache = require('../cache').create('mongo');
 
@@ -27,7 +28,7 @@ module.exports = function (module) {
 			}
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, data);
+				winston.warn('[database/mongo/hash] E11000 duplicate key, retrying setObject', { key, data, stack: new Error('e11000').stack });
 				return await module.setObject(key, data);
 			}
 			throw err;

--- a/src/database/mongo/sets.js
+++ b/src/database/mongo/sets.js
@@ -4,6 +4,7 @@ module.exports = function (module) {
 	const _ = require('lodash');
 	const helpers = require('./helpers');
 	const { secureRandom } = require('../../utils');
+	const winston = require('winston');
 
 	module.setAdd = async function (key, value) {
 		if (!Array.isArray(value)) {
@@ -28,7 +29,7 @@ module.exports = function (module) {
 			});
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, value);
+				winston.warn('[database/mongo/sets] E11000 duplicate key, retrying setAdd', { key, value, stack: new Error('e11000').stack });
 				return await module.setAdd(key, value);
 			}
 			throw err;
@@ -61,7 +62,7 @@ module.exports = function (module) {
 			await bulk.execute();
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, keys, value);
+				winston.warn('[database/mongo/sets] E11000 duplicate key, retrying setsAdd', { keys, value, stack: new Error('e11000').stack });
 				return await module.setsAdd(keys, value);
 			}
 			throw err;

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -451,7 +451,8 @@ module.exports = function (module) {
 			// https://jira.mongodb.org/browse/SERVER-14322
 			// https://docs.mongodb.org/manual/reference/command/findAndModify/#upsert-and-unique-index
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, increment, value);
+				const winston = require('winston');
+				winston.warn('[database/mongo/sorted] E11000 duplicate key, retrying sortedSetIncrBy', { key, increment, value, stack: new Error('e11000').stack });
 				return await module.sortedSetIncrBy(key, increment, value);
 			}
 			throw err;

--- a/src/database/mongo/sorted/add.js
+++ b/src/database/mongo/sorted/add.js
@@ -3,6 +3,7 @@
 module.exports = function (module) {
 	const helpers = require('../helpers');
 	const utils = require('../../../utils');
+	const winston = require('winston');
 
 	module.sortedSetAdd = async function (key, score, value) {
 		if (!key) {
@@ -20,7 +21,7 @@ module.exports = function (module) {
 			await module.client.collection('objects').updateOne({ _key: key, value: value }, { $set: { score: parseFloat(score) } }, { upsert: true });
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, score, value);
+				winston.warn('[database/mongo/sorted/add] E11000 duplicate key, retrying sortedSetAdd', { key, score, value, stack: new Error('e11000').stack });
 				return await module.sortedSetAdd(key, score, value);
 			}
 			throw err;


### PR DESCRIPTION
This patch replaces ad-hoc console.log calls used to debug E11000 duplicate-key upsert races in Mongo DB helper modules with structured warnings via the project's logger (winston).

Files changed:

[hash.js](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) — use [winston.warn](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) and include context when retrying [setObject](https://legendary-happiness-69vpv56jprp72pjv.github.dev/)
[add.js](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) — use [winston.warn](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) for [sortedSetAdd](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) retries
[sorted.js](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) — use [winston.warn](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) for [sortedSetIncrBy](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) retry
[sets.js](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) — use [winston.warn](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) for [setAdd](https://legendary-happiness-69vpv56jprp72pjv.github.dev/)/[setsAdd](https://legendary-happiness-69vpv56jprp72pjv.github.dev/) retries