### PR TITLE
refactor(mongo): use winston for E11000 duplicate-key logging

### DIFF
--- a/src/database/mongo/hash.js
+++ b/src/database/mongo/hash.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function (module) {
+	const winston = require('winston');
 	const helpers = require('./helpers');
 
 	const cache = require('../cache').create('mongo');
@@ -27,7 +28,7 @@ module.exports = function (module) {
 			}
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, data);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, key, data });
 				return await module.setObject(key, data);
 			}
 			throw err;
@@ -63,7 +64,7 @@ module.exports = function (module) {
 			}
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, data);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, data });
 				return await module.setObjectBulk(data);
 			}
 			throw err;
@@ -259,7 +260,7 @@ module.exports = function (module) {
 			// https://jira.mongodb.org/browse/SERVER-14322
 			// https://docs.mongodb.org/manual/reference/command/findAndModify/#upsert-and-unique-index
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, field, value);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, key, field, value });
 				return await module.incrObjectFieldBy(key, field, value);
 			}
 			throw err;

--- a/src/database/mongo/sets.js
+++ b/src/database/mongo/sets.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function (module) {
+	const winston = require('winston');
 	const _ = require('lodash');
 	const helpers = require('./helpers');
 	const { secureRandom } = require('../../utils');
@@ -28,7 +29,7 @@ module.exports = function (module) {
 			});
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, value);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, key, value });
 				return await module.setAdd(key, value);
 			}
 			throw err;
@@ -61,7 +62,7 @@ module.exports = function (module) {
 			await bulk.execute();
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, keys, value);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, keys, value });
 				return await module.setsAdd(keys, value);
 			}
 			throw err;

--- a/src/database/mongo/sorted/add.js
+++ b/src/database/mongo/sorted/add.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function (module) {
+	const winston = require('winston');
 	const helpers = require('../helpers');
 	const utils = require('../../../utils');
 
@@ -20,7 +21,7 @@ module.exports = function (module) {
 			await module.client.collection('objects').updateOne({ _key: key, value: value }, { $set: { score: parseFloat(score) } }, { upsert: true });
 		} catch (err) {
 			if (err && err.message.includes('E11000 duplicate key error')) {
-				console.log(new Error('e11000').stack, key, score, value);
+				winston.error('E11000 duplicate key error', { stack: new Error('e11000').stack, key, score, value });
 				return await module.sortedSetAdd(key, score, value);
 			}
 			throw err;


### PR DESCRIPTION
**Summary:**
Replace ad‑hoc [console.log(...)](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) calls used to log MongoDB duplicate-key (E11000) errors with structured [winston.error(...)](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) calls in Mongo-related modules. This centralizes error logging and ensures messages are captured by the project's logging stack.

**Files changed**
[hash.js](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) — use winston for E11000 logs; added [const winston = require('winston');](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1)
[sets.js](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) — use winston for E11000 logs; added [const winston = require('winston');](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1)
[add.js](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) — use winston for E11000 logs; added [const winston = require('winston');](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1)

**Motivation**
Ad‑hoc console logging bypasses centralized log handling and may not be captured by log aggregators or the runtime's dynamic logger settings. Using [winston](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) aligns error logging with the rest of the application and makes logs structured and easier to index.

**Behavior**
No functional change: duplicate-key errors are still retried (same retry logic remained). Only the logging mechanism changed.

**Validation**
Ran npm run lint locally. Lint completed with 0 errors and a single unrelated vendor warning.
Notes / follow-ups
There are other [console.log](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) usages in the repo; some are intended for CLI/user output and should remain. If desired, we can:
Audit server-side console output and replace unintended [console.log](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1)s with [winston](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1)/[logger](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1).
Route logs through the [logger](https://github.com/CMU-313/NodeBB.ai/compare/dcrodrig-/task-1?expand=1) module where dynamic runtime configuration is required.

**Suggested reviewers**
@julianlam (or the NodeBB maintainers), @barisusakli

**Labels**
area:logging
type:refactor
semver:patch
