### PR TITLE
refactor(privileges): simplify canDelete boolean expression in topics.js

### DIFF
--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -167,7 +167,9 @@ privsTopics.canDelete = async function (tid, uid) {
 	}
 
 	const { deleterUid } = topicData;
-	return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
+	const canDeleteAsOwner = isOwner && (deleterUid === 0 || deleterUid === topicData.uid);
+	const canDelete = allowedTo[0] && (canDeleteAsOwner || isModerator);
+	return canDelete;
 };
 
 privsTopics.canEdit = async function (tid, uid) {


### PR DESCRIPTION
jsb26: Refactor the binary expression on src/privileges/topics.js:170 to make it less complex

GitHub Copilot: Read [](file:///workspaces/NodeBB.ai/src/privileges/topics.js#160-160), lines 160 to 180

Read [](file:///workspaces/NodeBB.ai/src/privileges/topics.js#150-150), lines 150 to 159

Using "Apply Patch"


```

```
The binary expression on line 170 of topics.js has been refactored to reduce complexity and improve readability. The logic is now split into clear, named variables for easier understanding and maintenance.

Let me know if you need further changes or a review of other complex expressions.

Made changes.

jsb26: refactor src/privileges/topics.js:170 to make the binary expression less complex

GitHub Copilot: Enable GPT-5 mini for all clients
[object Object]

jsb26: @agent Enable: "Enable GPT-5 mini for all clients"

GitHub Copilot: I'll check the updated topics.js, your package.json scripts, and run a quick project error scan to ensure the refactor didn't introduce issues. I'll read the two files and get current lint/compile errors in parallel, then report results and next steps. 

Read [](file:///workspaces/NodeBB.ai/src/privileges/topics.js)

Read [](file:///workspaces/NodeBB.ai/package.json)

Checked workspace, no problems found

I'll summarize the change I made, what I ran to verify it, and next steps.

## What I changed
- Edited topics.js to simplify the complex binary expression at the return on the canDelete path.
- Replaced the single complex expression:
  - return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);
- With clearer named variables:
  - const canDeleteAsOwner = isOwner && (deleterUid === 0 || deleterUid === topicData.uid);
  - const canDelete = allowedTo[0] && (canDeleteAsOwner || isModerator);
  - return canDelete;

This keeps the original logic but splits it into two small, readable boolean expressions.

## What I ran (quick checks)
I ran these three reads/checks in parallel to confirm context and detect obvious issues:
- Read topics.js (to confirm the edit).
- Read package.json (to confirm scripts/dependencies).
- Ran an errors scan across the workspace.

Results: No errors found.

## Requirements coverage
- Refactor the binary expression on `src/privileges/topics.js:170` to be less complex — Done.

## Next steps (optional)
If you'd like me to be more thorough, I can:
- Run the project's linter (eslint) and tests.
- Add a small unit test for `privsTopics.canDelete` behavior (happy path + an edge case).
- Rename variables or add a short comment if you prefer a different naming style.

Commands you can run locally to lint/test:
```bash
npm run lint
npm test
```

## Completion
The complex binary expression was refactored into two named booleans for readability without changing behavior. I verified the workspace for errors and found none. Tell me if you want lint/tests run, a unit test added, or any other follow-ups.

jsb26: make a pull request

GitHub Copilot: I'll open a pull request that contains the refactor of the complex binary expression in topics.js (simplify canDelete logic). Expected outcome: a PR created on the repository with a descriptive title, summary, and the changes from the current branch. I'll include what I changed, why, and verification steps. I'll push the branch with the refactor and open the GitHub compare page so you can create the pull request (or I can open it for you). I'll run git status, confirm the branch, commit the change if needed, push the branch, and open the PR compare URL. Expected outcome: branch pushed to origin and the PR compare page opened. 

Ran terminal command: git status --porcelain=v1

Ran terminal command: git rev-parse --abbrev-ref HEAD

Ran terminal command: git add src/privileges/topics.js && git commit -m "refactor(privileges): simplify canDelete boolean expression in topics.js" || true

Ran terminal command: git push -u origin zijianzh/task-1

Progress update: I committed the refactor locally and pushed the branch to your fork at https://github.com/jsb26/NodeBB.ai on branch `zijianzh/task-1`. I'll open the GitHub new pull request URL so you can finalize/submit the PR. If you want, I can open the URL in your browser. 

Ran terminal command: $BROWSER https://github.com/jsb26/NodeBB.ai/pull/new/zijianzh/task-1

I've pushed the branch with the change and opened the PR creation page for you.

What I did
- Committed the refactor to topics.js with message:
  - "refactor(privileges): simplify canDelete boolean expression in topics.js"
- Pushed the branch `zijianzh/task-1` to your fork at https://github.com/jsb26/NodeBB.ai
- Opened the GitHub "create pull request" page for that branch:
  - https://github.com/jsb26/NodeBB.ai/pull/new/zijianzh/task-1

Next steps for you
- Open the link above to review the PR description and create the pull request against the upstream repository (CMU-313/NodeBB.ai).
- I can update the PR description to the text I prepared earlier, or open the PR for you if you prefer I do that next (requires write/PR permissions on upstream).

If you'd like, I can:
- Add a short unit test for `privsTopics.canDelete` covering owner/mod/admin cases.
- Run `npm run lint` and `npm test` and push any needed fixes.
- Create the PR on the upstream repo (if you grant permission / add me as a collaborator).

jsb26: write the description of the pull request

GitHub Copilot: Here's a polished pull request description you can paste into GitHub's PR body.

Title (suggested)
Refactor: simplify canDelete boolean expression in topics privileges

Description
---
Summary
- Simplifies a complex boolean expression in `privsTopics.canDelete` to improve readability and maintainability without changing runtime behavior.

What changed
- topics.js
  - Replaced the single complex return expression:
    - `return allowedTo[0] && ((isOwner && (deleterUid === 0 || deleterUid === topicData.uid)) || isModerator);`
  - With two named booleans and a final return:
    - `const canDeleteAsOwner = isOwner && (deleterUid === 0 || deleterUid === topicData.uid);`
    - `const canDelete = allowedTo[0] && (canDeleteAsOwner || isModerator);`
    - `return canDelete;`

Why
- The original expression was hard to parse and flagged as complex by maintainability checks.
- Splitting into named boolean variables makes the intent clearer (delete-as-owner vs. delete-as-moderator) and reduces cognitive load for future contributors.
- No change to business logic — behavior remains the same.

Verification
- Performed a workspace error scan after the change; no errors found.
- The change is minimal and behavior-preserving; still recommend running CI (lint + tests) to be safe.

How to test locally
- Lint and tests:
```bash
npm run lint
npm test
```
- Manual smoke test ideas:
  - As an administrator: verify topics can still be deleted.
  - As topic owner where `deleterUid` equals `0` or the topic owner uid: verify deletion allowed when `topics:delete` is allowed.
  - As moderator: verify deletion allowed when `topics:delete` is allowed.
  - Verify the existing `preventTopicDeleteAfterReplies` behavior still throws when appropriate.

Notes / Follow-ups
- I did not add unit tests in this change. If desired, I can add a small unit test for `privsTopics.canDelete` covering:
  - Administrator allowed
  - Owner allowed (with `deleterUid` 0 and matching uid)
  - Moderator allowed
  - Rejection when `preventTopicDeleteAfterReplies` blocks deletion
- This is a pure refactor with no API changes.

Checklist
- [x] Clear, behavior-preserving refactor
- [x] No workspace errors after change
- [ ] CI: lint passing
- [ ] CI: tests passing
- [ ] (Optional) Add unit tests for `privsTopics.canDelete`

If you want, I can:
- Add the unit tests and push them to this branch.
- Run the lint/tests locally and push any necessary fixes.