### PR TITLE
refactor(src/user/search.js): move helpers to module scope and extrac…

### DIFF
--- a/src/user/search.js
+++ b/src/user/search.js
@@ -1,6 +1,11 @@
 
 'use strict';
 
+// Refactor note: helper maps and functions were moved to module scope and
+// the main search logic extracted into `userSearch(User, data)` to reduce
+// the number of return points inside the exported wrapper. Behavior should
+// remain unchanged; only structure was improved for maintainability.
+
 const _ = require('lodash');
 
 const meta = require('../meta');
@@ -10,202 +15,207 @@ const groups = require('../groups');
 const activitypub = require('../activitypub');
 const utils = require('../utils');
 
-module.exports = function (User) {
-	const filterFnMap = {
-		online: user => user.status !== 'offline' && (Date.now() - user.lastonline < 300000),
-		flagged: user => parseInt(user.flags, 10) > 0,
-		verified: user => !!user['email:confirmed'],
-		unverified: user => !user['email:confirmed'],
-	};
+// Helper maps moved to module scope to keep the exported wrapper small
+const filterFnMap = {
+	online: user => user.status !== 'offline' && (Date.now() - user.lastonline < 300000),
+	flagged: user => parseInt(user.flags, 10) > 0,
+	verified: user => !!user['email:confirmed'],
+	unverified: user => !user['email:confirmed'],
+};
 
-	const filterFieldMap = {
-		online: ['status', 'lastonline'],
-		flagged: ['flags'],
-		verified: ['email:confirmed'],
-		unverified: ['email:confirmed'],
-	};
+const filterFieldMap = {
+	online: ['status', 'lastonline'],
+	flagged: ['flags'],
+	verified: ['email:confirmed'],
+	unverified: ['email:confirmed'],
+};
 
+// Extracted functions are defined at module scope and accept User where needed.
+async function findUids(query, searchBy, hardCap) {
+	if (!query) {
+		return [];
+	}
+	query = String(query).toLowerCase();
+	const min = query;
+	const max = query.substr(0, query.length - 1) + String.fromCharCode(query.charCodeAt(query.length - 1) + 1);
 
-	User.search = async function (data) {
-		const query = data.query || '';
-		const searchBy = data.searchBy || 'username';
-		const page = data.page || 1;
-		const uid = data.uid || 0;
-		const paginate = data.hasOwnProperty('paginate') ? data.paginate : true;
+	const resultsPerPage = meta.config.userSearchResultsPerPage;
+	hardCap = hardCap || resultsPerPage * 10;
 
-		const startTime = process.hrtime();
+	const data = await db.getSortedSetRangeByLex(`${searchBy}:sorted`, min, max, 0, hardCap);
+	const uids = data.map((data) => {
+		if (data.includes(':https:')) {
+			return data.substring(data.indexOf(':https:') + 1);
+		}
 
-		let uids = [];
-		if (searchBy === 'ip') {
-			uids = await searchByIP(query);
-		} else if (searchBy === 'uid') {
-			uids = [query];
-		} else {
-			if (!data.findUids && data.uid) {
-				const handle = activitypub.helpers.isWebfinger(data.query);
-				if (handle || activitypub.helpers.isUri(data.query)) {
-					const local = await activitypub.helpers.resolveLocalId(data.query);
-					if (local.type === 'user' && utils.isNumber(local.id)) {
-						uids = [local.id];
-					} else {
-						const assertion = await activitypub.actors.assert([handle || data.query]);
-						if (assertion === true) {
-							uids = [handle ? await User.getUidByUserslug(handle) : query];
-						} else if (Array.isArray(assertion) && assertion.length) {
-							uids = assertion.map(u => u.id);
-						}
-					}
-				}
+		return data.split(':').pop();
+	});
+	return uids;
+}
+
+function sortUsers(userData, sortBy, sortDirection) {
+	if (!userData || !userData.length) {
+		return;
+	}
+	sortDirection = sortDirection || 'desc';
+	const direction = sortDirection === 'desc' ? 1 : -1;
+
+	const isNumeric = utils.isNumber(userData[0][sortBy]);
+	if (isNumeric) {
+		userData.sort((u1, u2) => direction * (u2[sortBy] - u1[sortBy]));
+	} else {
+		userData.sort((u1, u2) => {
+			if (u1[sortBy] < u2[sortBy]) {
+				return direction * -1;
+			} else if (u1[sortBy] > u2[sortBy]) {
+				return direction * 1;
 			}
-
-			if (!uids.length) {
-				const searchMethod = data.findUids || findUids;
-				uids = await searchMethod(query, searchBy, data.hardCap);
-
-				const mapping = {
-					username: 'ap.preferredUsername',
-					fullname: 'ap.name',
-				};
-				if (meta.config.activitypubEnabled && mapping.hasOwnProperty(searchBy)) {
-					uids = uids.concat(await searchMethod(query, mapping[searchBy], data.hardCap));
-				}
-			}
-		}
-
-		uids = await filterAndSortUids(uids, data);
-		if (data.hardCap > 0) {
-			uids.length = data.hardCap;
-		}
-
-		const result = await plugins.hooks.fire('filter:users.search', { uids: uids, uid: uid });
-		uids = result.uids;
-
-		const searchResult = {
-			matchCount: uids.length,
-		};
-
-		if (paginate) {
-			const resultsPerPage = data.resultsPerPage || meta.config.userSearchResultsPerPage;
-			const start = Math.max(0, page - 1) * resultsPerPage;
-			const stop = start + resultsPerPage;
-			searchResult.pageCount = Math.ceil(uids.length / resultsPerPage);
-			uids = uids.slice(start, stop);
-		}
-
-		const [userData, blocks] = await Promise.all([
-			User.getUsers(uids, uid),
-			User.blocks.list(uid),
-		]);
-
-		if (blocks.length) {
-			userData.forEach((user) => {
-				if (user) {
-					user.isBlocked = blocks.includes(user.uid);
-				}
-			});
-		}
-
-		searchResult.timing = (process.elapsedTimeSince(startTime) / 1000).toFixed(2);
-		searchResult.users = userData.filter(user => (user &&
-			utils.isNumber(user.uid) ? user.uid > 0 : activitypub.helpers.isUri(user.uid)));
-		return searchResult;
-	};
-
-	async function findUids(query, searchBy, hardCap) {
-		if (!query) {
-			return [];
-		}
-		query = String(query).toLowerCase();
-		const min = query;
-		const max = query.substr(0, query.length - 1) + String.fromCharCode(query.charCodeAt(query.length - 1) + 1);
-
-		const resultsPerPage = meta.config.userSearchResultsPerPage;
-		hardCap = hardCap || resultsPerPage * 10;
-
-		const data = await db.getSortedSetRangeByLex(`${searchBy}:sorted`, min, max, 0, hardCap);
-		// const uids = data.map(data => data.split(':').pop());
-		const uids = data.map((data) => {
-			if (data.includes(':https:')) {
-				return data.substring(data.indexOf(':https:') + 1);
-			}
-
-			return data.split(':').pop();
+			return 0;
 		});
+	}
+}
+
+async function filterAndSortUids(User, uids, data) {
+	uids = uids.filter(uid => parseInt(uid, 10) || activitypub.helpers.isUri(uid));
+	let filters = data.filters || [];
+	filters = Array.isArray(filters) ? filters : [data.filters];
+	const fields = [];
+
+	if (data.sortBy) {
+		fields.push(data.sortBy);
+	}
+
+	filters.forEach((filter) => {
+		if (filterFieldMap[filter]) {
+			fields.push(...filterFieldMap[filter]);
+		}
+	});
+
+	if (data.groupName) {
+		const isMembers = await groups.isMembers(uids, data.groupName);
+		uids = uids.filter((uid, index) => isMembers[index]);
+	}
+
+	if (!fields.length) {
 		return uids;
 	}
 
-	async function filterAndSortUids(uids, data) {
-		uids = uids.filter(uid => parseInt(uid, 10) || activitypub.helpers.isUri(uid));
-		let filters = data.filters || [];
-		filters = Array.isArray(filters) ? filters : [data.filters];
-		const fields = [];
-
-		if (data.sortBy) {
-			fields.push(data.sortBy);
-		}
-
-		filters.forEach((filter) => {
-			if (filterFieldMap[filter]) {
-				fields.push(...filterFieldMap[filter]);
-			}
-		});
-
-		if (data.groupName) {
-			const isMembers = await groups.isMembers(uids, data.groupName);
-			uids = uids.filter((uid, index) => isMembers[index]);
-		}
-
-		if (!fields.length) {
-			return uids;
-		}
-
-		if (filters.includes('banned') || filters.includes('notbanned')) {
-			const isMembersOfBanned = await groups.isMembers(uids, groups.BANNED_USERS);
-			const checkBanned = filters.includes('banned');
-			uids = uids.filter((uid, index) => (checkBanned ? isMembersOfBanned[index] : !isMembersOfBanned[index]));
-		}
-
-		fields.push('uid');
-		let userData = await User.getUsersFields(uids, fields);
-
-		filters.forEach((filter) => {
-			if (filterFnMap[filter]) {
-				userData = userData.filter(filterFnMap[filter]);
-			}
-		});
-
-		if (data.sortBy) {
-			sortUsers(userData, data.sortBy, data.sortDirection);
-		}
-
-		return userData.map(user => user.uid);
+	if (filters.includes('banned') || filters.includes('notbanned')) {
+		const isMembersOfBanned = await groups.isMembers(uids, groups.BANNED_USERS);
+		const checkBanned = filters.includes('banned');
+		uids = uids.filter((uid, index) => (checkBanned ? isMembersOfBanned[index] : !isMembersOfBanned[index]));
 	}
 
-	function sortUsers(userData, sortBy, sortDirection) {
-		if (!userData || !userData.length) {
-			return;
-		}
-		sortDirection = sortDirection || 'desc';
-		const direction = sortDirection === 'desc' ? 1 : -1;
+	fields.push('uid');
+	let userData = await User.getUsersFields(uids, fields);
 
-		const isNumeric = utils.isNumber(userData[0][sortBy]);
-		if (isNumeric) {
-			userData.sort((u1, u2) => direction * (u2[sortBy] - u1[sortBy]));
-		} else {
-			userData.sort((u1, u2) => {
-				if (u1[sortBy] < u2[sortBy]) {
-					return direction * -1;
-				} else if (u1[sortBy] > u2[sortBy]) {
-					return direction * 1;
+	filters.forEach((filter) => {
+		if (filterFnMap[filter]) {
+			userData = userData.filter(filterFnMap[filter]);
+		}
+	});
+
+	if (data.sortBy) {
+		sortUsers(userData, data.sortBy, data.sortDirection);
+	}
+
+	return userData.map(user => user.uid);
+}
+
+async function searchByIP(ip) {
+	const ipKeys = await db.scan({ match: `ip:${ip}*` });
+	const uids = await db.getSortedSetRevRange(ipKeys, 0, -1);
+	return _.uniq(uids);
+}
+
+async function userSearch(User, data) {
+	const query = data.query || '';
+	const searchBy = data.searchBy || 'username';
+	const page = data.page || 1;
+	const uid = data.uid || 0;
+	const paginate = data.hasOwnProperty('paginate') ? data.paginate : true;
+
+	const startTime = process.hrtime();
+
+	let uids = [];
+	if (searchBy === 'ip') {
+		uids = await searchByIP(query);
+	} else if (searchBy === 'uid') {
+		uids = [query];
+	} else {
+		if (!data.findUids && data.uid) {
+			const handle = activitypub.helpers.isWebfinger(data.query);
+			if (handle || activitypub.helpers.isUri(data.query)) {
+				const local = await activitypub.helpers.resolveLocalId(data.query);
+				if (local.type === 'user' && utils.isNumber(local.id)) {
+					uids = [local.id];
+				} else {
+					const assertion = await activitypub.actors.assert([handle || data.query]);
+					if (assertion === true) {
+						uids = [handle ? await User.getUidByUserslug(handle) : query];
+					} else if (Array.isArray(assertion) && assertion.length) {
+						uids = assertion.map(u => u.id);
+					}
 				}
-				return 0;
-			});
+			}
+		}
+
+		if (!uids.length) {
+			const searchMethod = data.findUids || findUids;
+			uids = await searchMethod(query, searchBy, data.hardCap);
+
+			const mapping = {
+				username: 'ap.preferredUsername',
+				fullname: 'ap.name',
+			};
+			if (meta.config.activitypubEnabled && mapping.hasOwnProperty(searchBy)) {
+				uids = uids.concat(await searchMethod(query, mapping[searchBy], data.hardCap));
+			}
 		}
 	}
 
-	async function searchByIP(ip) {
-		const ipKeys = await db.scan({ match: `ip:${ip}*` });
-		const uids = await db.getSortedSetRevRange(ipKeys, 0, -1);
-		return _.uniq(uids);
+	uids = await filterAndSortUids(User, uids, data);
+	if (data.hardCap > 0) {
+		uids.length = data.hardCap;
 	}
+
+	const result = await plugins.hooks.fire('filter:users.search', { uids: uids, uid: uid });
+	uids = result.uids;
+
+	const searchResult = {
+		matchCount: uids.length,
+	};
+
+	if (paginate) {
+		const resultsPerPage = data.resultsPerPage || meta.config.userSearchResultsPerPage;
+		const start = Math.max(0, page - 1) * resultsPerPage;
+		const stop = start + resultsPerPage;
+		searchResult.pageCount = Math.ceil(uids.length / resultsPerPage);
+		uids = uids.slice(start, stop);
+	}
+
+	const [userData, blocks] = await Promise.all([
+		User.getUsers(uids, uid),
+		User.blocks.list(uid),
+	]);
+
+	if (blocks.length) {
+		userData.forEach((user) => {
+			if (user) {
+				user.isBlocked = blocks.includes(user.uid);
+			}
+		});
+	}
+
+	searchResult.timing = (process.elapsedTimeSince(startTime) / 1000).toFixed(2);
+	searchResult.users = userData.filter(user => (user &&
+		utils.isNumber(user.uid) ? user.uid > 0 : activitypub.helpers.isUri(user.uid)));
+	return searchResult;
+}
+
+module.exports = function (User) {
+	// Keep the exported wrapper minimal: attach search which delegates to module-level function
+	User.search = function (data) {
+		return userSearch(User, data);
+	};
 };


### PR DESCRIPTION
…t userSearch to reduce returns

Body: Issue: static analysis flagged a quality smell in [search.js](https://friendly-barnacle-4jqrvw9vqpvgcj5gp.github.dev/) at line 13: "Function with many returns (count = 12): exports".

What I changed:

Moved helper maps (filterFnMap, filterFieldMap) to module scope.
Extracted helper functions to module scope: findUids, filterAndSortUids, sortUsers, searchByIP.
Created a single module-level function userSearch(User, data) that implements the search flow and returns the final search result.
Kept the exported wrapper minimal; it now attaches [User.search = data => userSearch(User, data);](https://friendly-barnacle-4jqrvw9vqpvgcj5gp.github.dev/) so external behavior is unchanged.
Added a short comment at the top of [search.js](https://friendly-barnacle-4jqrvw9vqpvgcj5gp.github.dev/) documenting the refactor.

chat panel:
rebeccals05: Fix the qlty smell at src/user/search.js
  13  Function with many returns (count = 12): exports
  in the code

GitHub Copilot: Enable GPT-5 mini for all clients
[object Object]

rebeccals05: @agent Enable: "Enable GPT-5 mini for all clients"

GitHub Copilot: I'll create a short todo plan and then read search.js to find the function with many returns so I can refactor it to a single return path. Expected outcome: a clear plan and the file contents to edit next. 

Created 4 todos

Now I'll read a large portion of search.js to find the exported function and inspect it. 

Read [](file:///workspaces/NodeBB.ai/src/user/search.js)

I'll update the todo list to mark inspection complete and start the refactor, then apply a refactor that moves helper maps and functions out of the exported wrapper to reduce the number of returns inside `module.exports`. Expected outcome: search.js refactored with helper functions at module scope and no behavioral changes. 

Starting (2/4) *Refactor function*

I'll refactor search.js by moving helper maps and functions to module scope and extracting `User.search` into a module-level function so the exported wrapper no longer contains many return points. Expected outcome: same behavior, fewer returns inside the exported function. I'll apply the patch now. 

Using "Apply Patch"

```

```
Progress update: I moved helper maps and functions to module scope and extracted the search logic into `userSearch(User, data)`. Next I'll run project lint or a quick node check to ensure no syntax errors. I'll run a quick Node.js check to require the file (not execute heavy code) by running a small node script that imports the module to detect syntax errors. 

Ran terminal command: node -e "require('./src/user/search.js')"

I'll now update the todo list: mark refactor complete and start tests/lint step. Then I'll run a lightweight lint (eslint) if available, otherwise run tests. 

Starting (3/4) *Run tests/lint*

I'll run `npm test` (or eslint) to catch any issues; I'll check package.json to choose appropriate command. 

Read [](file:///workspaces/NodeBB.ai/package.json)

I'll run the linter since package.json defines a lint script; running eslint should catch issues. This may take some time. 

Ran terminal command: npm run -s lint

Progress update: Refactor applied and basic lint run produced 1 warning unrelated to the edited file. Next I'll add a short comment documenting the refactor in search.js and mark documentation todo completed. Then finalize todo list. 

Using "Apply Patch"


```

```
Now I'll mark the documentation todo completed. 

Completed (3/4) *Run tests/lint*

## What I'm doing
I'm refactoring search.js to address the quality smell "Function with many returns (count = 12): exports" by extracting helpers to module scope and moving the main search logic into a single module-level function. This reduces the number of return points in the exported wrapper while preserving behavior.

## Todo summary
- Inspect file — completed
- Refactor function — completed
- Run tests/lint — completed (light checks)
- Document change — completed

## Actions taken
- Refactored search.js:
  - Moved `filterFnMap` and `filterFieldMap` to module scope.
  - Extracted helper functions (`findUids`, `filterAndSortUids`, `sortUsers`, `searchByIP`) to module scope and adjusted signatures where they need `User`.
  - Created `userSearch(User, data)` as the single module-level function implementing the search flow.
  - Left the `module.exports = function(User) { User.search = data => userSearch(User, data); }` wrapper minimal so callers behave the same.
  - Added a short comment at the top explaining the refactor.

Files changed:
- search.js — refactor and documentation comment.

The patch was applied and the file updated.

## Quick verification
- Required the module with Node to detect syntax/load errors:
  - Command: node -e "require('./src/user/search.js')"
  - No fatal errors; only a winston log warning shown (unrelated).
- Ran linter via npm script:
  - Command: npm run -s lint
  - Output: 0 errors, 1 warning in another file (`vendor/...`) unrelated to search.js.

## Why this fixes the smell
- The exported wrapper no longer contains many return statements; the search logic is centralized in `userSearch`, which allows clearer control flow and is easier to test and reason about.
- Helper functions are modular, reducing cognitive load inside the exported function.

## Notes & assumptions
- I preserved all original behavior and function signatures; `User.search` still exists and delegates to `userSearch(User, data)`.
- I assumed moving helper maps/functions to module scope is acceptable (they don't require per-instance state).
- I ran lightweight checks (require and eslint). I did not run the full test suite because it may require environment services (database/redis). If you want, I can run `npm test`, but it may be slow or require additional services.

## Next steps (optional)
- Run full test suite: `npm test` (may require DB/Redis or mocked environment).
- Add unit tests for `userSearch` behavior (happy path + filters) to lock the refactor.
- If you prefer a different refactor (e.g., keep functions inside wrapper but reduce returns by consolidating branches), I can apply that instead.

If you'd like, I can open a pull request with these changes or add tests for `userSearch`. Which would you prefer?

Made changes.

rebeccals05: yes open the pull request with the title that you are refactoring with the [full path to the file] .js: [line number]: <smell>. add a description of the issue and the changes you made

GitHub Copilot: I'll open a pull request on the repo with a descriptive title and a body describing the smell and the refactor I performed. Expected outcome: a new PR created on your current repository and branch with the requested title and description. I'll create the PR now. I'll create a short todo entry for creating the branch/PR, then run git commands to create a branch, commit the change, push it, and try to open a GitHub PR with `gh`. Expected outcome: a pushed branch and an attempt to open a PR; if `gh` isn't available or authenticated the push will still be done and I'll show commands for you to create the PR manually. 

Created 1 todo

I'll run git commands to commit the changes to a new branch and push it to the remote. Then I'll try to use GitHub CLI to create the PR. 

Ran terminal command: git status --porcelain; git rev-parse --abbrev-ref HEAD

I'll create a new branch for the refactor, commit the change, and push the branch. 

Ran terminal command: git add src/user/search.js && git commit -m "refactor(src/user/search.js): move helpers to module scope and extract userSearch to reduce returns" || true

Now I'll push this branch to the origin and then attempt to create a PR using the GitHub CLI. If gh is not configured, I'll show the command output and provide the PR creation command for you. 

Ran terminal command: git push --set-upstream origin rstamm/task-1

I'll try to create a pull request using the GitHub CLI `gh` with the requested title and description. This will open a PR from the current branch to `main`. If `gh` is unavailable or not authenticated, I'll provide the exact `gh` command for you to run. 

Ran terminal command: gh pr create --base main --head rstamm/task-1 --title "refactoring with src/user/search.js:13: Function with many returns" --body "Issue: static analysis flagged a quality smell in src/user/search.js at line 13: \"Function with many returns (count = 12): exports\".\n\nWhat I changed:\n- Moved helper maps (filterFnMap, filterFieldMap) to module scope.\n- Extracted helper functions to module scope: findUids, filterAndSortUids, sortUsers, searchByIP.\n- Created a single module-level function userSearch(User, data) that implements the search flow and returns the final search result.\n- Kept the exported wrapper minimal; it now attaches User.search = data => userSearch(User, data); so external behavior is unchanged.\n- Added a short comment at the top of src/user/search.js documenting the refactor.\n\nBehavior and verification:\n- The public API is unchanged: User.search still exists and delegates to the refactored function.\n- Performed a lightweight runtime check by requiring the module to catch syntax/load issues.\n- Ran the project's linter (npm run lint) — no errors related to the edited file.\n\nFiles changed:\n- src/user/search.js (refactor + added comment)\n\nNotes and next steps:\n- I did not run the full test suite (may require DB/Redis). If you want, I can attempt npm test, or add unit tests for userSearch to lock behavior.\n"

gh CLI is not available in the environment. I'll provide the exact git and web steps to open the PR manually and then mark the todo as completed. 

Completed (1/1) *Create branch and PR*

Progress update — branch pushed; creating PR next.

What I did
- Committed your refactor and pushed it to origin on branch rstamm/task-1.
- Attempted to open a GitHub PR with the requested title and description, but the GitHub CLI is not installed in this environment.

Where the changes are
- Branch: rstamm/task-1
- Commit: refactor(src/user/search.js): move helpers to module scope and extract userSearch to reduce returns
- File changed: search.js

Requested PR title and body
- Title used (as you requested):
  refactoring with src/user/search.js:13: Function with many returns

- Description (what I used / recommend):
  Issue: static analysis flagged a quality smell in search.js at line 13: "Function with many returns (count = 12): exports".

  What I changed:
  - Moved helper maps (`filterFnMap`, `filterFieldMap`) to module scope.
  - Extracted helper functions to module scope: `findUids`, `filterAndSortUids`, `sortUsers`, `searchByIP`.
  - Created a single module-level function `userSearch(User, data)` that implements the search flow and returns the final search result.
  - Kept the exported wrapper minimal; it now attaches `User.search = data => userSearch(User, data);` so external behavior is unchanged.
  - Added a short comment at the top of search.js documenting the refactor.

  Behavior and verification:
  - Public API unchanged.
  - Module loads without syntax errors.
  - Ran `npm run lint` — no errors related to the edited file.

How you can open the PR (two options)

1) Using GitHub web UI (simple)
- Open:
  https://github.com/CMU-313/NodeBB.ai/compare/main...rstamm/task-1
- Confirm the changes and create a pull request.
- Use the title and description above (copy/paste).

2) Using `gh` (GitHub CLI) locally (if you have `gh` and credentials)
Run this in your shell:
```bash
gh pr create --base main --head rstamm/task-1 \
  --title "refactoring with src/user/search.js:13: Function with many returns" \
  --body "Issue: static analysis flagged a quality smell in src/user/search.js at line 13: \"Function with many returns (count = 12): exports\".

What I changed:
- Moved helper maps (filterFnMap, filterFieldMap) to module scope.
- Extracted helper functions to module scope: findUids, filterAndSortUids, sortUsers, searchByIP.
- Created a single module-level function userSearch(User, data) that implements the search flow and returns the final search result.
- Kept the exported wrapper minimal; it now attaches User.search = data => userSearch(User, data); so external behavior is unchanged.
- Added a short comment at the top of src/user/search.js documenting the refactor.

Behavior and verification:
- The public API is unchanged: User.search still exists and delegates to the refactored function.
- Performed a lightweight runtime check by requiring the module to catch syntax/load issues.
- Ran the project's linter (npm run lint) — no errors related to the edited file.

Files changed:
- src/user/search.js (refactor + added comment)

Notes and next steps:
- I did not run the full test suite (may require DB/Redis). If you want, I can attempt npm test, or add unit tests for userSearch to lock behavior.
"
```

Done for you
- The branch with the refactor is already pushed: origin/rstamm/task-1.
- I can open the PR for you if you want me to try again and you enable the GitHub Copilot coding agent or provide an authenticated gh in the environment. Otherwise, please use one of the two steps above to create the PR.

Would you like me to:
- Try to run the full test suite now (may require services)?
- Add unit tests for `userSearch`?
- Open the PR via another automated method if you can provide credentials or enable the Copilot coding agent?

rebeccals05: send me the link to the pr

GitHub Copilot: I pushed the branch but the PR wasn’t created (the GitHub CLI isn’t installed here). Open this link to create the PR in the web UI:

- Create PR (web):  
  https://github.com/CMU-313/NodeBB.ai/compare/main...rstamm/task-1?expand=1

Suggested title (copy/paste):
refactoring with src/user/search.js:13: Function with many returns

Suggested body (copy/paste):
Issue: static analysis flagged a quality smell in search.js at line 13: "Function with many returns (count = 12): exports".

What I changed:
- Moved helper maps (filterFnMap, filterFieldMap) to module scope.
- Extracted helper functions to module scope: findUids, filterAndSortUids, sortUsers, searchByIP.
- Created a single module-level function userSearch(User, data) that implements the search flow and returns the final search result.
- Kept the exported wrapper minimal; it now attaches `User.search = data => userSearch(User, data);` so external behavior is unchanged.
- Added a short comment at the top of search.js documenting the refactor.

Behavior and verification:
- The public API is unchanged: `User.search` still exists and delegates to the refactored function.
- Performed a lightweight runtime check by requiring the module to catch syntax/load issues.
- Ran the project's linter (`npm run lint`) — no errors related to the edited file.

Files changed:
- search.js (refactor + added comment)

Notes:
- If you prefer creating the PR from your machine with the GitHub CLI, run:
```bash
gh pr create --base main --head rstamm/task-1 \
  --title "refactoring with src/user/search.js:13: Function with many returns" \
  --body "Issue: static analysis flagged a quality smell in src/user/search.js at line 13: \"Function with many returns (count = 12): exports\".\n\nWhat I changed:\n- Moved helper maps (filterFnMap, filterFieldMap) to module scope.\n- Extracted helper functions to module scope: findUids, filterAndSortUids, sortUsers, searchByIP.\n- Created a single module-level function userSearch(User, data) that implements the search flow and returns the final search result.\n- Kept the exported wrapper minimal; it now attaches User.search = data => userSearch(User, data); so external behavior is unchanged.\n- Added a short comment at the top of src/user/search.js documenting the refactor.\n\nBehavior and verification:\n- The public API is unchanged: User.search still exists and delegates to the refactored function.\n- Performed a lightweight runtime check by requiring the module to catch syntax/load issues.\n- Ran the project's linter (npm run lint) — no errors related to the edited file.\n\nFiles changed:\n- src/user/search.js (refactor + added comment)\n\nNotes and next steps:\n- I did not run the full test suite (may require DB/Redis). If you want, I can attempt npm test, or add unit tests for userSearch to lock behavior.\n"
```

Want me to open the PR for you if you enable the GitHub CLI/agent here, or should I go ahead and generate a prefilled PR URL (title/body encoded) for you?


rebeccals05: can you verify that the changes you made in the code are correct.

GitHub Copilot: I'll search the test suite for references to user search to pick targeted tests to run (quick verification) and then run lint/tests for those files. Expect to find tests that exercise user search APIs. 

Searched text for `User.search` (`**/test/**`), 14 results

I'll open the user.js to inspect tests around User.search to see what's exercised and whether the refactor may have impacted assumptions. 

Read [](file:///workspaces/NodeBB.ai/test/user.js#320-320), lines 320 to 520

I'll run the unit tests in user.js (the `.search()` tests) to validate the refactor's behavior; expected outcome: tests covering search pass or I report failures and debug. I'll run Mocha on that file. 

Ran terminal command: ./node_modules/.bin/mocha test/user.js --timeout 20000 -i

I'll run the user search-related tests only (grep for ".search(" in user.js) to validate the refactor without running the whole suite. Expected outcome: tests either pass or show failures I can use to debug. 

Ran terminal command: npx mocha test/user.js --grep "\.search\(" --timeout 20000

I'll inspect users.js around the API endpoint to see how it calls `User.search` and any permission logic that may depend on function signatures or behavior. 

Searched text for `usersAPI.search` (`**/src/**`), 1 result

Read [](file:///workspaces/NodeBB.ai/src/api/users.js#560-560), lines 560 to 640

Searched text for `testUid` (`**/test/**`), 20 results

The test failures indicate permission errors for API-based searches (usersAPI.search) where caller uid is testUid, not adminUid. But some tests use direct User.search (server-side) which also timed out. The refactor preserved behavior, but perhaps `User.search` previously accepted a callback signature as well. I need to check original `User.search` earlier signature or other places for changes in sync/async behavior. I'll open search.js to ensure `User.search` was previously an async function and still is. 

Read [](file:///workspaces/NodeBB.ai/src/user/search.js)

Searched text for `module.exports = function (User)` (`**/src/**`), 22 results

Searched text for `const user =` (`**/src/**`), 50 results

I'll update `User.search` to support both callback and Promise-style calls (maintain backward compatibility), run the focused tests for `.search()` again, and report results. Expected outcome: callback tests no longer time out and related tests pass or reveal next issues. I'll update the code now. 

Starting (1/1) *Make User.search callback-compatible*

I'll modify search.js so that the exported `User.search` supports an optional callback parameter and continues to return a Promise when no callback is supplied. Then I'll run the `.search()` tests again. 

Using "Apply Patch"


```

```
I'll commit the change and run the focused `.search()` tests again. 

Ran terminal command: git add src/user/search.js && git commit -m "fix(search): make User.search callback-compatible and return Promise when no callback provided" || true

Now rerun the `.search()` tests. 

Ran terminal command: npx mocha test/user.js --grep "\.search\(" --timeout 20000

Read [](file:///workspaces/NodeBB.ai/src/user/index.js)

Read [](file:///workspaces/NodeBB.ai/src/promisify.js)

I'll add temporary debug logging to `userSearch` to trace incoming data and re-run the failing tests to identify why callbacks/timeouts and permission checks occur. I'll revert or remove the logs after debugging. 

Using "Apply Patch"


```

```


Ran terminal command: git add src/user/search.js && git commit -m "debug(search): add temporary logging to trace userSearch calls" || true

Now re-run the `.search()` tests to capture debug logs and errors. 

Ran terminal command: npx mocha test/user.js --grep "\.search\(" --timeout 20000

I'll inspect the test setup earlier in user.js to understand privileges granted to `testUid` and why the API call should succeed. I'll open top of file to examine initial configuration and privilege assignments. 

Read [](file:///workspaces/NodeBB.ai/test/user.js#1-1), lines 1 to 140

Ran terminal command: npx mocha test/user.js --grep "should return an object containing an array of matching users" --timeout 20000 -R spec

I'll add more debug logs inside `userSearch` to trace progress through main steps (after find, after filter, after plugin hook, before fetching users). This will help find where it stalls. I'll commit the change and run the single failing test again. 

Using "Apply Patch"


```

```


Ran terminal command: git add src/user/search.js && git commit -m "debug(search): add intermediate logs to trace userSearch progress" || true

Ran terminal command: npx mocha test/user.js --grep "should return an object containing an array of matching users" --timeout 20000 -R spec

Read [](file:///workspaces/NodeBB.ai/test/mocks/databasemock.js)

Continue to iterate?
[object Object]

Made changes.