### PR TITLE
Refactor getTopicPosts to use options object and resolve Qlty smell

### DIFF
--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -174,7 +174,7 @@ Topics.getTopicWithPosts = async function (topicData, set, uid, start, stop, rev
 		thumbs,
 		events,
 	] = await Promise.all([
-		Topics.getTopicPosts(topicData, set, start, stop, uid, reverse),
+		Topics.getTopicPosts({ topicData, set, start, stop, uid, reverse }),
 		categories.getCategoryData(topicData.cid),
 		categories.getTagWhitelist([topicData.cid]),
 		plugins.hooks.fire('filter:topic.thread_tools', { topic: topicData, uid: uid, tools: [] }),

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -22,7 +22,8 @@ module.exports = function (Topics) {
 		await Topics.addPostToTopic(postData.tid, postData);
 	};
 
-	Topics.getTopicPosts = async function (topicData, set, start, stop, uid, reverse) {
+	Topics.getTopicPosts = async function (options) {
+		const { topicData, set, start, stop, uid, reverse } = options;
 		if (!topicData) {
 			return [];
 		}


### PR DESCRIPTION
This pull request refactors the getTopicPosts function in src/topics/posts.js to accept a single options object instead of six parameters, addressing the Qlty code smell for too many parameters.

- Updated usage in src/topics/index.js to match the new signature.
- No errors found after the change.
- Improves code maintainability and readability.

Reason for change:
Qlty reported a code smell for excessive parameters in getTopicPosts. This refactor resolves that issue and aligns with best practices.