### PR TITLE
Improve security of qlty installation in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update \
         redis-server \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://qlty.sh | /bin/bash \
+# Replace curl | bash with a safer alternative
+RUN curl -o /tmp/qlty.sh https://qlty.sh \
+ && chmod +x /tmp/qlty.sh \
+ && /tmp/qlty.sh \
  && mv ~/.qlty/bin/qlty /usr/local/bin/qlty \
- && rm -rf ~/.qlty \
- && qlty --version
+ && rm -rf ~/.qlty /tmp/qlty.sh


### PR DESCRIPTION
This pull request addresses a security concern in the .devcontainer/Dockerfile where curl was piped directly to bash to install qlty. This practice is considered unsafe as it can lead to unintended code execution.