### PR TITLE
9/30/2026 Class Activity Extraneous console log 

### DIFF
--- a/public/src/client/world.js
+++ b/public/src/client/world.js
@@ -100,7 +100,6 @@ define('forum/world', ['topicList', 'search', 'sort', 'hooks', 'alerts', 'api', 
 		};
 
 		let visibility = localStorage.getItem('world:show-categories');
-		console.log('got value', visibility);
 		visibility = visibility ? visibility === 'true' : true; // localStorage values are strings
 		update();
 


### PR DESCRIPTION
**NOTE**: This PR Description is all generated by AI as well it is kind of funny!

Description This PR removes an extraneous debug log left in the client code. It's a small, non-functional cleanup to avoid leaking implementation details to the browser console and to satisfy lint/noise rules.

What

Removed the debug statement:
[console.log('got value', visibility)](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/) from [world.js](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/)
Why

Debug console logs in production client files create noisy output and can leak internal state.
Removing them improves cleanliness of client-side logs and aligns with linting best-practices (no-console in production).
Low-risk change: does not alter control flow or user-visible behavior.

How

Deleted the single console.log line where localStorage value was being read and coerced to boolean.
No other logic changed: the value is still read from [localStorage](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/), coerced to boolean, and used by the existing [update()](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/) function.
Testing

Manual verification (before applying change):
Confirm the debug line exists:
Manual verification (after applying change):
Confirm the debug line is gone:

Run linter to ensure no lint regressions:
Run test suite (this repo uses mocha/nyc; optional but recommended if you run full test):
Quick smoke in browser (optional):
Load the app, open devtools console, navigate to the page containing the world view, and confirm the previous debug message no longer appears.

Files changed

[world.js](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/) — removed [console.log('got value', visibility)](https://organic-space-tribble-g44qg6gvqqj9fvvw9.github.dev/).
Risk & Rollback

Risk: negligible. Change is purely a removal of a log statement.
Rollback: revert the commit or re-add the line if you absolutely need the debug output for local investigations.