### PR TITLE
tests: avoid binding to default port in test mock; use ephemeral port…

### DIFF
--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -55,7 +55,12 @@ nconf.set('url_parsed', urlObject);
 nconf.set('base_url', `${urlObject.protocol}//${urlObject.host}`);
 nconf.set('secure', urlObject.protocol === 'https:');
 nconf.set('use_port', !!urlObject.port);
-nconf.set('port', urlObject.port || nconf.get('port') || (nconf.get('PORT_ENV_VAR') ? nconf.get(nconf.get('PORT_ENV_VAR')) : false) || 4567);
+nconf.set('port', urlObject.port || nconf.get('port') || (nconf.get('PORT_ENV_VAR') ? nconf.get(nconf.get('PORT_ENV_VAR')) : false) || 0);
+
+// In test environment we want to avoid binding to the default port (4567)
+// to prevent EADDRINUSE when multiple test runs or a running instance exist.
+// Force the test runtime to use an ephemeral port assigned by the OS.
+nconf.set('port', 0);
 
 // cookies don't provide isolation by port: http://stackoverflow.com/a/16328399/122353
 const domain = nconf.get('cookieDomain') || urlObject.hostname;


### PR DESCRIPTION
… to prevent EADDRINUSE


Summary

Tests were failing intermittently with EADDRINUSE because the test harness fell back to a hard-coded port (4567). This change forces the test mock to use an ephemeral (OS-assigned) port so tests no longer try to bind to a fixed port and cause address-in-use flakes.
What I changed

File: [databasemock.js](https://musical-space-trout-5grr5jwq5w99h44gr.github.dev/)
Change: replace hard-coded fallback port 4567 with an ephemeral port (set [nconf.set('port', 0)](https://musical-space-trout-5grr5jwq5w99h44gr.github.dev/)), with a short comment explaining why.
Why this fixes the problem

Hard-coded ports in test code are brittle: if another process (or another test run) already occupies the port, tests fail with EADDRINUSE.
Using port 0 delegates port selection to the OS, avoiding collisions and making test runs more reliable and parallel-friendly.
Verification / testing notes

After the change I ran the test runner locally in this environment. NodeBB started listening on 0.0.0.0:0 (ephemeral port) and the previous EADDRINUSE error was prevented during the test startup phase.
I didn't run the entire test suite to completion here due to environment time/limits. Please let CI run the full test suite to confirm everything passes in your usual CI matrix.
Risk / scope

Small, localized change only to test mocks — no production code paths were changed.
Low risk; improves test reliability.
Files changed

[databasemock.js](https://musical-space-trout-5grr5jwq5w99h44gr.github.dev/) — one small change.
