### PR TITLE
9/30 Class Activity AI Refactor Global State Mutation

### DIFF
--- a/src/categories/search.js
+++ b/src/categories/search.js
@@ -63,7 +63,7 @@ module.exports = function (Categories) {
 			}
 			return c1.order - c2.order;
 		});
-		searchResult.timing = (process.elapsedTimeSince(startTime) / 1000).toFixed(2);
+	searchResult.timing = (utils.elapsedTimeSince(startTime) / 1000).toFixed(2);
 		searchResult.categories = categoryData.filter(c => cids.includes(c.cid));
 		return searchResult;
 	};

--- a/src/search.js
+++ b/src/search.js
@@ -49,7 +49,7 @@ search.search = async function (data) {
 		}
 	}
 
-	result.time = (process.elapsedTimeSince(start) / 1000).toFixed(2);
+	result.time = (utils.elapsedTimeSince(start) / 1000).toFixed(2);
 	return result;
 };
 

--- a/src/user/search.js
+++ b/src/user/search.js
@@ -105,7 +105,7 @@ module.exports = function (User) {
 			});
 		}
 
-		searchResult.timing = (process.elapsedTimeSince(startTime) / 1000).toFixed(2);
+		searchResult.timing = (utils.elapsedTimeSince(startTime) / 1000).toFixed(2);
 		searchResult.users = userData.filter(user => (user &&
 			utils.isNumber(user.uid) ? user.uid > 0 : activitypub.helpers.isUri(user.uid)));
 		return searchResult;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,15 +4,16 @@ const crypto = require('crypto');
 const nconf = require('nconf');
 const path = require('node:path');
 
-process.profile = function (operation, start) {
-	console.log('%s took %d milliseconds', operation, process.elapsedTimeSince(start));
-};
+const utils = { ...require('../public/src/utils.common') };
 
-process.elapsedTimeSince = function (start) {
+utils.elapsedTimeSince = function (start) {
 	const diff = process.hrtime(start);
 	return (diff[0] * 1e3) + (diff[1] / 1e6);
 };
-const utils = { ...require('../public/src/utils.common') };
+
+utils.profile = function (operation, start) {
+	console.log('%s took %d milliseconds', operation, utils.elapsedTimeSince(start));
+};
 
 utils.getLanguage = function () {
 	const meta = require('./meta');

--- a/test/utils.js
+++ b/test/utils.js
@@ -475,9 +475,11 @@ describe('Utility Methods', () => {
 	});
 
 	it('should profile function', (done) => {
+		delete require.cache[require.resolve('../src/utils')];
+		const { profile } = require('../src/utils');
 		const st = process.hrtime();
 		setTimeout(() => {
-			process.profile('it took', st);
+			profile('it took', st);
 			done();
 		}, 500);
 	});


### PR DESCRIPTION
### Summary
Move timing helpers out of the global [process](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) object and into the application [utils](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) module. This removes a global mutation (quality smell) and makes the timing utilities explicit, testable, and easier to discover. Update all internal call sites and tests that used [process.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) / [process.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) to the new [utils](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) API.

### Why
Mutating globals (the [process](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) object) hides behavior, creates implicit dependencies, and makes testing and maintenance harder. This change eliminates that global mutation and exposes the helpers as explicit, importable utilities.

### What I changed

- Removed assignments to:
- [process.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- [process.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Added exported helpers on [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/):
- [utils.elapsedTimeSince(start)](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — returns elapsed milliseconds (uses [process.hrtime](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) internally)
- [utils.profile(operation, start)](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — logs timing using [utils.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Replaced all internal call sites that referenced the global helpers to use the new helpers:
- [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — use [utils.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — use [utils.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — use [utils.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Updated tests to use the new helpers:
- [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) — import { profile } from [src/utils](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) in the profiling test
- Fixed initialization order in [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) so [utils](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) is defined before methods are attached.

Files changed (high level)
- Modified: [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Modified: [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Modified: [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Modified: [search.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)
- Modified: [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)

### Backwards compatibility
This is a breaking change for any external code (plugins or integrations) that relied on [process.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) or [process.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/). For internal code in this repository, callers were updated.

Migration options for plugin authors:
- Preferred: require the utils module and use the APIs:
- const { elapsedTimeSince, profile } = require('path-to-app/src/utils');
- If immediate backward-compatibility is required, we can add a one-release shim that proxies the old [process.*](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) properties to [utils.*](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) while emitting a deprecation warning. I did not add a shim in this PR to avoid perpetuating the global mutation.

### Testing
Recommended to run the targeted test(s) and a quick lint:
- Run the targeted mocha test (the profiling test)
- Run the full test suite
- Lint
I ran the profiling test during development and fixed an initialization-order bug in [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/); after the fix the profiling test is expected to run normally. Please run the full test suite in CI.

### Risk & roll-back
- Risk: low-to-moderate. Internal code updated, but external plugins that expected [process.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) will break. No database or runtime schema changes.
- Roll-back: revert this branch; alternatively add a compatibility shim in [utils.js](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) that assigns [process.profile = utils.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) and [process.elapsedTimeSince = utils.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) until plugin authors migrate.

### Notes / Follow-ups
- Search & refactor other global mutations across the codebase (if any).
- Consider documenting the utility API in developer docs so plugin authors know to import [src/utils](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/) instead of inspecting [process](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/).
- Optionally add a short deprecation notice in CHANGELOG / release notes about removal of [process.profile](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/)/[process.elapsedTimeSince](https://redesigned-memory-rqqv9g6x4w7c5jp4.github.dev/).

### Suggested reviewers
- Core maintainers and plugin maintainers (those who maintain integration points).
- Someone familiar with search & timing logic: @maintainer, @plugins-owner (replace with actual GitHub usernames in PR).