### PR TITLE
Added functionality to filter posts by unanswered

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,42 @@ Interested in a sublicense agreement for use of NodeBB in a non-free/restrictive
 * Unofficial IRC community &ndash; channel `#nodebb` on Libera.chat
 * [Follow us on Twitter](http://www.twitter.com/NodeBB/ "NodeBB Twitter")
 * [Like us on Facebook](http://www.facebook.com/NodeBB/ "NodeBB Facebook")
+
+## New Feature: Unanswered Posts Filter
+
+### API Endpoint
+
+**GET /api/unanswered**
+
+This endpoint retrieves a list of posts that have not received any replies.
+
+#### Query Parameters
+- `start` (optional): The starting index for pagination (default: 0).
+- `stop` (optional): The ending index for pagination (default: 19).
+- `reverse` (optional): Whether to reverse the order of the results (default: false).
+
+#### Response
+- `posts`: An array of unanswered posts. Each post object includes details such as `pid`, `content`, and `replies` (which will always be 0).
+
+#### Example Request
+```bash
+curl -X GET 'http://<your-nodebb-instance>/api/unanswered?start=0&stop=10'
+```
+
+#### Example Response
+```json
+{
+  "posts": [
+    {
+      "pid": 123,
+      "content": "This is an unanswered post.",
+      "replies": 0
+    },
+    {
+      "pid": 124,
+      "content": "Another unanswered post.",
+      "replies": 0
+    }
+  ]
+}
+```

--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const topics = require('../topics');
@@ -10,6 +9,15 @@ module.exports = function (Posts) {
 		const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
 		const posts = await Posts.getPostsByPids(pids, uid);
 		return await user.blocks.filter(uid, posts);
+	};
+
+	Posts.getUnansweredPosts = async function (set, start, stop, uid, reverse) {
+		const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
+		const posts = await Posts.getPostsByPids(pids, uid);
+
+		// Filter posts that have no replies
+		const unansweredPosts = posts.filter(post => post && post.replies === 0);
+		return await user.blocks.filter(uid, unansweredPosts);
 	};
 
 	Posts.isMain = async function (pids) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -162,6 +162,18 @@ function addCoreRoutes(app, router, middleware, mounts) {
 	_mounts.globalMod(router, middleware, controllers);
 	_mounts['well-known'](router, middleware, controllers);
 
+	// Add route for fetching unanswered posts
+	router.get('/api/unanswered', middleware.authenticateRequest, async (req, res) => {
+		try {
+			const { start = 0, stop = 19, reverse = false } = req.query;
+			const uid = req.user ? req.user.uid : 0;
+			const unansweredPosts = await require('../posts/topics').getUnansweredPosts('posts:recent', start, stop, uid, reverse);
+			res.json({ posts: unansweredPosts });
+		} catch (err) {
+			res.status(500).json({ error: err.message });
+		}
+	});
+
 	addRemountableRoutes(app, router, middleware, mounts);
 
 	const relativePath = nconf.get('relative_path');

--- a/test/posts/unanswered.js
+++ b/test/posts/unanswered.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+const request = require('supertest');
+const app = require('../../src/app'); // Adjust path to your app entry point
+
+describe('GET /api/unanswered', function () {
+	it('should return a list of unanswered posts', async function () {
+		const res = await request(app)
+			.get('/api/unanswered')
+			.query({ start: 0, stop: 10 });
+
+		expect(res.status).to.equal(200);
+		expect(res.body).to.have.property('posts');
+		expect(res.body.posts).to.be.an('array');
+
+		// Check that all posts have 0 replies
+		res.body.posts.forEach(post => {
+			expect(post).to.have.property('replies', 0);
+		});
+	});
+
+	it('should handle errors gracefully', async function () {
+		const res = await request(app)
+			.get('/api/unanswered')
+			.query({ start: -1, stop: -10 }); // Invalid range
+
+		expect(res.status).to.equal(500);
+		expect(res.body).to.have.property('error');
+	});
+});


### PR DESCRIPTION
User story: As a instructor, I want to filter posts by “unanswered,” so that I can focus on helping students whose questions haven’t yet been addressed.