### PR TITLE
Add global post search bar to header

### DIFF
--- a/public/src/client/header.js
+++ b/public/src/client/header.js
@@ -8,16 +8,19 @@ define('forum/header', [
 ], function (unread, notifications, chat, alerts) {
 	const module = {};
 
-	module.prepareDOM = function () {
-		if (app.user.uid > 0) {
-			unread.initUnreadTopics();
-		}
-		notifications.prepareDOM();
-		chat.prepareDOM();
-		handleStatusChange();
-		createHeaderTooltips();
-		handleLogout();
-	};
+       module.prepareDOM = function () {
+	       if (app.user.uid > 0) {
+		       unread.initUnreadTopics();
+	       }
+	       notifications.prepareDOM();
+	       chat.prepareDOM();
+	       handleStatusChange();
+	       createHeaderTooltips();
+	       handleLogout();
+	       require(['forum/postsearch'], function (PostSearch) {
+		       PostSearch.init();
+	       });
+       };
 
 	function handleStatusChange() {
 		$('[component="header/usercontrol"] [data-status]').off('click').on('click', function (e) {

--- a/public/src/client/postsearch.js
+++ b/public/src/client/postsearch.js
@@ -1,0 +1,33 @@
+define('forum/postsearch', ['api', 'alerts'], function (api, alerts) {
+define('forum/postsearch', ['api', 'alerts'], function (api, alerts) {
+	const PostSearch = {};
+
+	PostSearch.init = function () {
+		const $input = $('#post-search-input');
+		const $results = $('#post-search-results');
+		if (!$input.length || !$results.length) return;
+
+		$input.on('keyup', function () {
+			const query = $input.val().trim();
+			if (query.length < 2) {
+				$results.empty();
+				return;
+			}
+			api.get('/api/search', { term: query, in: 'posts', showAs: 'posts', searchOnly: 1 })
+				.then(function (data) {
+					$results.empty();
+					if (data && data.posts && data.posts.length) {
+						data.posts.slice(0, 10).forEach(function (post) {
+							const html = `<div class="post-search-result"><a href="/post/${post.pid}">${post.content.slice(0, 100)}...</a></div>`;
+							$results.append(html);
+						});
+					} else {
+						$results.html('<div class="text-muted">No results</div>');
+					}
+				})
+				.catch(alerts.error);
+		});
+	};
+
+	return PostSearch;
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/header/brand.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/header/brand.tpl
@@ -1,28 +1,33 @@
 {{{ if (brand:logo || (config.showSiteTitle || widgets.brand-header.length)) }}}
 <div class="container-lg px-md-4 brand-container">
-	<div class="col-12 d-flex border-bottom pb-3 {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
-		{{{ if (brand:logo || config.showSiteTitle) }}}
-		<div component="brand/wrapper" class="d-flex align-items-center gap-3 p-2 rounded-1 align-content-stretch ">
-			{{{ if brand:logo }}}
-			<a component="brand/anchor" href="{{{ if brand:logo:url }}}{brand:logo:url}{{{ else }}}{relative_path}/{{{ end }}}" title="[[global:header.brand-logo]]">
-				<img component="brand/logo" alt="{{{ if brand:logo:alt }}}{brand:logo:alt}{{{ else }}}[[global:header.brand-logo]]{{{ end }}}" class="{brand:logo:display}" src="{brand:logo}?{config.cache-buster}" />
-			</a>
-			{{{ end }}}
+       <div class="col-12 d-flex border-bottom pb-3 {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
+	       {{{ if (brand:logo || config.showSiteTitle) }}}
+	       <div component="brand/wrapper" class="d-flex align-items-center gap-3 p-2 rounded-1 align-content-stretch ">
+		       {{{ if brand:logo }}}
+		       <a component="brand/anchor" href="{{{ if brand:logo:url }}}{brand:logo:url}{{{ else }}}{relative_path}/{{{ end }}}" title="[[global:header.brand-logo]]">
+			       <img component="brand/logo" alt="{{{ if brand:logo:alt }}}{brand:logo:alt}{{{ else }}}[[global:header.brand-logo]]{{{ end }}}" class="{brand:logo:display}" src="{brand:logo}?{config.cache-buster}" />
+		       </a>
+		       {{{ end }}}
 
-			{{{ if config.showSiteTitle }}}
-			<a component="siteTitle" class="text-truncate align-self-stretch align-items-center d-flex" href="{{{ if title:url }}}{title:url}{{{ else }}}{relative_path}/{{{ end }}}">
-				<h1 class="fs-6 fw-bold text-body mb-0">{config.siteTitle}</h1>
-			</a>
-			{{{ end }}}
-		</div>
-		{{{ end }}}
-		{{{ if widgets.brand-header.length }}}
-		<div data-widget-area="brand-header" class="flex-fill gap-3 p-2 align-self-center">
-			{{{each widgets.brand-header}}}
-			{{./html}}
-			{{{end}}}
-		</div>
-		{{{ end }}}
-	</div>
+		       {{{ if config.showSiteTitle }}}
+		       <a component="siteTitle" class="text-truncate align-self-stretch align-items-center d-flex" href="{{{ if title:url }}}{title:url}{{{ else }}}{relative_path}/{{{ end }}}">
+			       <h1 class="fs-6 fw-bold text-body mb-0">{config.siteTitle}</h1>
+		       </a>
+		       {{{ end }}}
+	       </div>
+	       {{{ end }}}
+	       <!-- Post Search Bar -->
+	       <div class="d-flex align-items-center ms-4" style="min-width:300px;">
+		       <input id="post-search-input" class="form-control form-control-sm" type="text" placeholder="Search posts..." autocomplete="off" />
+		       <div id="post-search-results" class="bg-white border rounded shadow-sm position-absolute mt-5" style="z-index:1000; min-width:300px;"></div>
+	       </div>
+	       {{{ if widgets.brand-header.length }}}
+	       <div data-widget-area="brand-header" class="flex-fill gap-3 p-2 align-self-center">
+		       {{{each widgets.brand-header}}}
+		       {{{./html}}}
+		       {{{end}}}
+	       </div>
+	       {{{ end }}}
+       </div>
 </div>
 {{{ end }}}


### PR DESCRIPTION
## Summary
This PR adds a global post search bar to the site header. Users can now search for posts from any page using the new search bar at the top. Results appear in a dropdown as you type, and clicking a result takes you to the post.

## Details
- Added a search input to the header (brand area)
- Created a new client script to handle live post search and display results
- Integrated with the existing /api/search endpoint (no backend changes required)
- Results are limited to 10 and show a snippet of post content

## Testing
- Start the server and open the forum
- Type in the new search bar in the header
- Matching post results should appear as you type
- Clicking a result navigates to the post

Closes: user story for searchbar and filter for posts