### PR TITLE
feat: Add "Unpopular Posts" feature with API, frontend tab, and tests

### DIFF
--- a/public/src/client/unpopular.js
+++ b/public/src/client/unpopular.js
@@ -1,0 +1,13 @@
+'use strict';
+
+define('forum/unpopular', ['topicList'], function (topicList) {
+	const Unpopular = {};
+
+	Unpopular.init = function () {
+		app.enterRoom('unpopular_topics');
+
+		topicList.init('unpopular');
+	};
+
+	return Unpopular;
+});

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -31,4 +31,16 @@ navigation.get = async function (uid) {
 	return data.filter((navItem, i) => pass[i]);
 };
 
+navigation.addUnpopularTab = async function () {
+	const unpopularTab = {
+		route: '/unpopular',
+		text: 'Unpopular',
+		icon: 'fa-eye-slash',
+		enabled: true,
+		groups: [],
+	};
+
+	await admin.save(unpopularTab);
+};
+
 require('../promisify')(navigation);

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -42,4 +42,5 @@ module.exports = function (app, middleware, controllers) {
 		middleware.canViewUsers,
 		middleware.checkAccountPermissions,
 	], helpers.tryRoute(controllers.accounts.edit.uploadPicture));
+	router.get('/unpopular', [...middlewares], helpers.tryRoute(controllers.api.getUnpopularTopics));
 };

--- a/test/api.js
+++ b/test/api.js
@@ -688,4 +688,15 @@ describe('API', async () => {
 			assert(schema[prop], `"${prop}" was found in response, but is not defined in schema (path: ${method} ${path}, context: ${context})`);
 		});
 	}
+
+	describe('GET /api/unpopular', () => {
+		it('should fetch unpopular topics with fewer than 5 views', async () => {
+			const response = await request.get('/api/unpopular?cid=1');
+			assert.strictEqual(response.statusCode, 200);
+			assert(Array.isArray(response.body));
+			response.body.forEach((topic) => {
+				assert(topic.viewcount < 5);
+			});
+		});
+	});
 });


### PR DESCRIPTION
Summary:
This PR introduces the "Unpopular Posts" feature, allowing instructors and admins to identify under-engaged posts with fewer than 5 views. The feature includes a new API endpoint, frontend integration, and tests.

Changes:
API Endpoint:

Added /api/unpopular to fetch topics with fewer than 5 views.
Utilized the [viewcount](https://turbo-giggle-5j75j7pgrw627wg7.github.dev/) field in the database to filter topics.
Frontend Integration:

Created a new "Unpopular" tab in the UI.
Added a client script ([unpopular.js](https://turbo-giggle-5j75j7pgrw627wg7.github.dev/)) to handle the tab's functionality.
Updated navigation to dynamically include the "Unpopular" tab.
Tests:

Added a test case for the /api/unpopular endpoint to ensure it fetches topics correctly.
Purpose:
This feature helps instructors and admins re-highlight overlooked discussions, ensuring no important topics are missed.