### PR TITLE
Add anonymous posting feature with UI and backend integration

### DIFF
--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -446,5 +446,54 @@ define('forum/topic/posts', [
 		});
 	};
 
+	// Add a checkbox for anonymous posting in the post creation UI
+	function addAnonymousOption() {
+		const postForm = document.querySelector('#post-form');
+		if (postForm) {
+			const anonymousCheckbox = document.createElement('div');
+			anonymousCheckbox.innerHTML = `
+				<div class="form-check">
+					<input class="form-check-input" type="checkbox" id="anonymousPost" name="anonymousPost">
+					<label class="form-check-label" for="anonymousPost">
+						Post Anonymously
+					</label>
+				</div>
+			`;
+			postForm.appendChild(anonymousCheckbox);
+		}
+	}
+
+	document.addEventListener('DOMContentLoaded', addAnonymousOption);
+
+	// Modify the post submission logic to include the anonymous option
+	function modifyPostSubmission() {
+		const postForm = document.querySelector('#post-form');
+		if (postForm) {
+			postForm.addEventListener('submit', (event) => {
+				const anonymousCheckbox = document.querySelector('#anonymousPost');
+				if (anonymousCheckbox && anonymousCheckbox.checked) {
+					const formData = new FormData(postForm);
+					formData.append('anonymous', true);
+
+					// Example: Modify the form submission to include the anonymous flag
+					fetch(postForm.action, {
+						method: 'POST',
+						body: formData,
+					}).then(response => {
+						if (response.ok) {
+							window.location.reload();
+						} else {
+							console.error('Failed to submit post');
+						}
+					});
+
+					event.preventDefault(); // Prevent default form submission
+				}
+			});
+		}
+	}
+
+	document.addEventListener('DOMContentLoaded', modifyPostSubmission);
+
 	return Posts;
 });

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -14,7 +14,7 @@ const utils = require('../utils');
 module.exports = function (Posts) {
 	Posts.create = async function (data) {
 		// This is an internal method, consider using Topics.reply instead
-		const { uid, tid, _activitypub, sourceContent } = data;
+		const { uid, tid, _activitypub, sourceContent, anonymous } = data;
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
@@ -23,12 +23,15 @@ module.exports = function (Posts) {
 			throw new Error('[[error:invalid-uid]]');
 		}
 
+		// Handle anonymous posts
+		const postUid = anonymous ? 0 : uid;
+
 		if (data.toPid) {
-			await checkToPid(data.toPid, uid);
+			await checkToPid(data.toPid, postUid);
 		}
 
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
-		let postData = { pid, uid, tid, content, sourceContent, timestamp };
+		let postData = { pid, uid: postUid, tid, content, sourceContent, timestamp, anonymous };
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'anonymous',
 ];
 
 module.exports = function (Posts) {


### PR DESCRIPTION
Implemented anonymous posting feature with UI and backend integration.

Changes:
Frontend ([posts.js](https://ubiquitous-yodel-xr5x4r5wrvfvvwg.github.dev/)):

Added a checkbox to the post creation form for selecting anonymous posting.
Updated the form submission logic to include the [anonymous](https://ubiquitous-yodel-xr5x4r5wrvfvvwg.github.dev/) flag when the checkbox is selected.
Backend ([create.js](https://ubiquitous-yodel-xr5x4r5wrvfvvwg.github.dev/)):

Modified the post creation logic to handle the [anonymous](https://ubiquitous-yodel-xr5x4r5wrvfvvwg.github.dev/) flag.
Ensured posts marked as anonymous are associated with a [uid](https://ubiquitous-yodel-xr5x4r5wrvfvvwg.github.dev/) of 0.
These changes allow users to create posts anonymously, ensuring their identity is hidden while maintaining functionality.