### PR TITLE
Feature for Marking Posts Urgent

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -245,6 +245,12 @@
 	"open-composer": "Open composer",
 	"post-quick-reply": "Quick reply",
 
+	"urgency": "Urgency",
+	"urgency:normal": "Normal",
+	"urgency:low": "Low",
+	"urgency:medium": "Medium",
+	"urgency:high": "High",
+
 	"navigator.index": "Post %1 of %2",
 	"navigator.unread": "%1 unread",
 	"upvote-post": "Upvote post",

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -28,7 +28,9 @@ module.exports = function (Posts) {
 		}
 
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
-		let postData = { pid, uid, tid, content, sourceContent, timestamp };
+		// Urgency: integer enum (0 = normal/default)
+		const urgency = data.urgency !== undefined ? parseInt(data.urgency, 10) : 0;
+		let postData = { pid, uid, tid, content, sourceContent, timestamp, urgency };
 
 		if (data.toPid) {
 			postData.toPid = data.toPid;

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -198,6 +198,13 @@ module.exports = function (Posts) {
 			editor: data.uid,
 		};
 
+		// preserve urgency if not provided; otherwise coerce to int
+		if (data.urgency !== undefined) {
+			editPostData.urgency = parseInt(data.urgency, 10);
+		} else if (postData && postData.urgency !== undefined) {
+			editPostData.urgency = postData.urgency;
+		}
+
 		// For posts in scheduled topics, if edited before, use edit timestamp
 		editPostData.edited = topicData.scheduled ? (postData.edited || postData.timestamp) + 1 : Date.now();
 

--- a/src/upgrades/20250930-add-post-urgency.js
+++ b/src/upgrades/20250930-add-post-urgency.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const db = require('../database');
+
+module.exports = async function (done) {
+	// Set urgency=0 for posts that don't have the field yet
+	try {
+		const ids = await db.getSortedSetRange('posts:pid', 0, -1);
+		if (!ids || !ids.length) {
+			return done();
+		}
+
+		const keys = ids.map(pid => `post:${pid}`);
+		const posts = await db.getObjects(keys, ['urgency']);
+		const bulk = [];
+		posts.forEach((p, idx) => {
+			if (p && (p.urgency === null || p.urgency === undefined)) {
+				bulk.push([`post:${ids[idx]}`, { urgency: 0 }]);
+			}
+		});
+		if (bulk.length) {
+			await db.setObjectBulk(bulk);
+		}
+		done();
+	} catch (err) {
+		done(err);
+	}
+};

--- a/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
@@ -62,6 +62,20 @@ $(document).ready(function () {
 				}
 			});
 
+				// Inject minimal styles for post urgency badges
+				$(function () {
+					const css = `
+					.post-urgency{font-weight:600;font-size:0.75rem;line-height:1;color:#fff}
+					.post-urgency--level-1{background:#6c757d}
+					.post-urgency--level-2{background:#ffc107;color:#000}
+					.post-urgency--level-3{background:#dc3545}
+					`;
+					const style = document.createElement('style');
+					style.type = 'text/css';
+					style.appendChild(document.createTextNode(css));
+					document.head.appendChild(style);
+				});
+
 			const bottomBar = $('[component="bottombar"]');
 			let stickyTools = null;
 			const location = config.theme.topMobilebar ? 'top' : 'bottom';

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -44,6 +44,13 @@
 					</div>
 
 					<a class="fw-bold text-nowrap text-truncate" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+						{{{ if ./urgency }}}
+						<span class="post-urgency post-urgency--level-{./urgency} ms-2 d-inline-flex align-items-center rounded-1 px-2 py-0 text-xs">
+							{{{ if ./urgency == 1 }}}[[topic:urgency:low]]{{{ end }}}
+							{{{ if ./urgency == 2 }}}[[topic:urgency:medium]]{{{ end }}}
+							{{{ if ./urgency == 3 }}}[[topic:urgency:high]]{{{ end }}}
+						</span>
+						{{{ end }}}
 				</div>
 
 				{{{ each posts.user.selectedGroups }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -13,6 +13,16 @@
 			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
 			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
 		</div>
+
+		<div class="mt-2 d-flex align-items-center gap-2">
+			<label class="mb-0 text-muted small">[[topic:urgency]]</label>
+			<select name="urgency" class="form-select form-select-sm w-auto">
+				<option value="0">[[topic:urgency:normal]]</option>
+				<option value="1">[[topic:urgency:low]]</option>
+				<option value="2">[[topic:urgency:medium]]</option>
+				<option value="3">[[topic:urgency:high]]</option>
+			</select>
+		</div>
 		<div>
 			<div class="d-flex justify-content-end gap-2">
 				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>


### PR DESCRIPTION
Issue Link: https://github.com/CMU-313/NodeBB.ai/issues/132

Context
Add a multi-level "urgency" field for posts so authors can mark replies/topics with a priority level. This enables users to mark posts as Normal/Low/Medium/High; the value is stored on the post object and displayed in the topic UI.

What changed
- Backend
  - create.js — accept and persist `urgency` on post creation (default 0).
  - edit.js — preserve/update `urgency` on post edits.
  - 20250930-add-post-urgency.js — migration to set missing `urgency` → 0.
- Frontend / Theme
  - quickreply.tpl — add an urgency select to quick-reply (name="urgency", values 0–3).
  - post.tpl — render a compact urgency badge next to author when urgency > 0.
  - harmony.js — inject minimal CSS for urgency badge styling.
- I18n
  - topic.json — added labels for urgency (Normal/Low/Medium/High).

How I tested
- Required/loaded modified server modules to validate no syntax errors.
- Confirmed templates and language keys were updated.
- Quick manual smoke checks (module loads). UI behavior should be verified in a running instance:
  - Use quick-reply on a topic, set urgency, submit, then inspect the saved post object to confirm `urgency` field is present and correct.

Notes & next steps
- Current server-side code coerces `urgency` to integer but does not enforce a max range or role-based caps — recommend adding validation (0–3) and permission checks if needed.
- I injected CSS via theme JS for simplicity; we can move styles into the theme stylesheet if preferred.
- I did not yet add the field to the full composer page; I can add a small client-side enhancement (hook: `action:composer.enhance`) to inject the select into the full composer so compose page + quick-reply both support urgency.
- Recommended follow-ups: unit/integration tests for create/edit with `urgency`, add validation, add admin setting for enabling/disabling urgency or role limits.

Tests to run locally
- Smoke load server modules:
  node -e "require('./src/posts/create.js'); require('./src/posts/edit.js'); console.log('loaded')"
- Run migration (your normal upgrade flow) to populate existing posts.
- Use the quick-reply UI to submit a reply with urgency and inspect `post:PID` to confirm persistence.

Summary
Small, backward-compatible change that adds an integer `urgency` to posts, a quick-reply control to set it, and a visible badge in the UI. If you want, I can now:
- add composer enhancement for the full composer,
- add server-side validation and tests,
- move CSS to theme stylesheet.