### PR TITLE
feat(api/topics): allow logged-in users to post anonymously

### DIFF
--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -11,10 +11,21 @@ const websockets = require('../socket.io');
 const events = require('../events');
 
 exports.setDefaultPostData = function (reqOrSocket, data) {
+	// Preserve the authenticated caller id for permission/rate-limit checks
 	data.uid = reqOrSocket.uid;
+	// Keep an internal copy of the real author uid so we can store posts as anonymous
+	data._uid = reqOrSocket.uid;
 	data.req = exports.buildReqObject(reqOrSocket, { ...data });
 	data.timestamp = Date.now();
 	data.fromQueue = false;
+
+	// Only honour anonymous posting when the caller is a logged-in local user
+	if (data.anonymous) {
+		if (!data._uid || parseInt(data._uid, 10) === 0) {
+			// If the caller isn't a logged-in user, ignore the anonymous flag
+			data.anonymous = false;
+		}
+	}
 };
 
 // creates a slimmed down version of the request object


### PR DESCRIPTION
Preserve authenticated caller id on requests as data._uid Honor a boolean anonymous flag (only for logged-in local users) when requested, store the post/topic owner as uid = 0 (guest) so it renders anonymously keep enforcement (privileges, rate-limits, queuing, link checks) using the real user id (data._uid) Use guest-handle validation for anonymous posts so a custom handle can be supplied for display Ensure notifications and post-summary building use the real caller for correctness Files changed:

helpers.js — record _uid, normalize anonymous flag create.js — set stored uid = 0 for anonymous posts; use _uid for checks and notification paths Notes / follow-ups:

Current changes do not persist the real author on the stored post (no audit field). If you need an admin-only audit trail, we should add a moderation-only field (or separate log). Recommend adding unit tests:
logged-in user creates topic/reply with anonymous: true → post stored with uid === 0, checks enforced against real user anonymous flag ignored for guests / uid=0
handle validation and notifications behavior verified