### PR TITLE
feat: Add "Unanswered Questions" sort option for category topics

### DIFF
--- a/public/language/en-GB/admin/settings/post.json
+++ b/public/language/en-GB/admin/settings/post.json
@@ -9,6 +9,7 @@
 	"sorting.most-votes": "Most Votes",
 	"sorting.most-posts": "Most Posts",
 	"sorting.most-views": "Most Views",
+	"sorting.unreplied": "Unanswered Questions",
 	"sorting.topic-default": "Default Topic Sorting",
 	"length": "Post Length",
 	"post-queue": "Post Queue",

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -217,6 +217,7 @@
 	"most-votes": "Most Votes",
 	"most-posts": "Most Posts",
 	"most-views": "Most Views",
+	"unreplied": "Unanswered Questions",
 
 	"stale.title": "Create new topic instead?",
 	"stale.warning": "The topic you are replying to is quite old. Would you like to create a new topic instead, and reference this one in your reply?",

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -22,7 +22,7 @@ const categoryController = module.exports;
 const url = nconf.get('url');
 const relative_path = nconf.get('relative_path');
 const validSorts = [
-	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views',
+	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views', 'unreplied',
 ];
 
 categoryController.get = async function (req, res, next) {

--- a/src/middleware/helpers.js
+++ b/src/middleware/helpers.js
@@ -28,53 +28,89 @@ helpers.try = function (middleware) {
 };
 
 helpers.buildBodyClass = function (req, res, templateData = {}) {
-	const clean = req.path.replace(/^\/api/, '').replace(/^\/|\/$/g, '');
-	const parts = clean.split('/').slice(0, 3);
-	parts.forEach((p, index) => {
-		try {
-			p = slugify(decodeURIComponent(p));
-		} catch (err) {
-			winston.error(`Error decoding URI: ${p}`);
-			winston.error(err.stack);
-			p = '';
-		}
-		p = validator.escape(String(p));
-		parts[index] = index ? `${parts[0]}-${p}` : `page-${p || 'home'}`;
-	});
-	const { template } = templateData;
-	if (template) {
-		parts.push(`template-${template.name.split('/').join('-')}`);
-	}
+	const parts = [];
+	
+	// Process URL path parts
+	parts.push(...helpers._processUrlParts(req.path));
+	
+	// Add template-specific classes
+	helpers._addTemplateClasses(parts, templateData);
+	
+	// Add breadcrumb classes
+	helpers._addBreadcrumbClasses(parts, templateData);
+	
+	// Add custom body classes
+	helpers._addCustomBodyClasses(parts, templateData);
+	
+	// Add status and theme classes
+	helpers._addStatusAndThemeClasses(parts, res);
+	
+	// Add user authentication class
+	helpers._addUserAuthClass(parts, req);
+	
+	return parts.join(' ');
+};
 
-	if (template && template.topic) {
+helpers._processUrlParts = function (path) {
+	const clean = path.replace(/^\/api/, '').replace(/^\/|\/$/g, '');
+	const parts = clean.split('/').slice(0, 3);
+	
+	return parts.map((p, index) => helpers._processUrlPart(p, index, parts[0]));
+};
+
+helpers._processUrlPart = function (part, index, firstPart) {
+	let processedPart = part;
+	
+	try {
+		processedPart = slugify(decodeURIComponent(part));
+	} catch (err) {
+		winston.error(`Error decoding URI: ${part}`);
+		winston.error(err.stack);
+		processedPart = '';
+	}
+	
+	processedPart = validator.escape(String(processedPart));
+	return index ? `${firstPart}-${processedPart}` : `page-${processedPart || 'home'}`;
+};
+
+helpers._addTemplateClasses = function (parts, templateData) {
+	const { template } = templateData;
+	
+	if (!template) return;
+	
+	parts.push(`template-${template.name.split('/').join('-')}`);
+	
+	if (template.topic) {
 		parts.push(`page-topic-category-${templateData.category.cid}`);
 		parts.push(`page-topic-category-${slugify(templateData.category.name)}`);
 	}
-
-	if (template && template.chats && templateData.roomId) {
+	
+	if (template.chats && templateData.roomId) {
 		parts.push(`page-user-chats-${templateData.roomId}`);
 	}
+};
 
-	if (Array.isArray(templateData.breadcrumbs)) {
-		templateData.breadcrumbs.forEach((crumb) => {
-			if (crumb && crumb.hasOwnProperty('cid')) {
-				parts.push(`parent-category-${crumb.cid}`);
-			}
-		});
-	}
+helpers._addBreadcrumbClasses = function (parts, templateData) {
+	if (!Array.isArray(templateData.breadcrumbs)) return;
+	
+	templateData.breadcrumbs.forEach((crumb) => {
+		if (crumb && crumb.hasOwnProperty('cid')) {
+			parts.push(`parent-category-${crumb.cid}`);
+		}
+	});
+};
 
+helpers._addCustomBodyClasses = function (parts, templateData) {
 	if (templateData && templateData.bodyClasses) {
 		parts.push(...templateData.bodyClasses);
 	}
+};
 
+helpers._addStatusAndThemeClasses = function (parts, res) {
 	parts.push(`page-status-${res.statusCode}`);
-
 	parts.push(`theme-${(meta.config['theme:id'] || '').split('-')[2]}`);
+};
 
-	if (req.loggedIn) {
-		parts.push('user-loggedin');
-	} else {
-		parts.push('user-guest');
-	}
-	return parts.join(' ');
+helpers._addUserAuthClass = function (parts, req) {
+	parts.push(req.loggedIn ? 'user-loggedin' : 'user-guest');
 };

--- a/src/middleware/helpers.js
+++ b/src/middleware/helpers.js
@@ -54,11 +54,17 @@ helpers.buildBodyClass = function (req, res, templateData = {}) {
 helpers._processUrlParts = function (path) {
 	const clean = path.replace(/^\/api/, '').replace(/^\/|\/$/g, '');
 	const parts = clean.split('/').slice(0, 3);
+	const processedParts = [];
 	
-	return parts.map((p, index) => helpers._processUrlPart(p, index, parts[0]));
+	parts.forEach((p, index) => {
+		const processedPart = helpers._processUrlPart(p, index, processedParts[0]);
+		processedParts[index] = processedPart;
+	});
+	
+	return processedParts;
 };
 
-helpers._processUrlPart = function (part, index, firstPart) {
+helpers._processUrlPart = function (part, index, firstProcessedPart) {
 	let processedPart = part;
 	
 	try {
@@ -70,7 +76,7 @@ helpers._processUrlPart = function (part, index, firstPart) {
 	}
 	
 	processedPart = validator.escape(String(processedPart));
-	return index ? `${firstPart}-${processedPart}` : `page-${processedPart || 'home'}`;
+	return index ? `${firstProcessedPart}-${processedPart}` : `page-${processedPart || 'home'}`;
 };
 
 helpers._addTemplateClasses = function (parts, templateData) {

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -23,6 +23,7 @@
 						<option value="most_posts">[[admin/settings/post:sorting.most-posts]]</option>
 						<option value="most_votes">[[admin/settings/post:sorting.most-votes]]</option>
 						<option value="most_views">[[admin/settings/post:sorting.most-views]]</option>
+						<option value="unreplied">[[admin/settings/post:sorting.unreplied]]</option>
 					</select>
 				</div>
 

--- a/src/views/partials/category/sort.tpl
+++ b/src/views/partials/category/sort.tpl
@@ -35,5 +35,11 @@
 				<i class="flex-shrink-0 fa fa-fw text-secondary"></i>
 			</a>
 		</li>
+		<li>
+			<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" href="#" data-sort="unreplied" role="menuitem">
+				<span class="flex-grow-1">[[topic:unreplied]]</span>
+				<i class="flex-shrink-0 fa fa-fw text-secondary fa-reply"></i>
+			</a>
+		</li>
 	</ul>
 </div>


### PR DESCRIPTION
## Add "Unanswered Questions" Sort Option for Categories

Overview
Implements user story: "As a professor, I want an easy way to identify unanswered questions, so that I can provide help where it's currently needed."
Closes Issue #103

Adds a new sorting option to category topic lists that filters and displays only topics with no replies, helping instructors quickly identify students who need assistance.

Changes Made
Backend:

Added [unreplied](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) to valid sorts in category controller
Enhanced category topic fetching to filter unreplied topics using existing [Topics.filterUnrepliedTids()](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/)
Updated topic count logic to properly handle unreplied filtering

Frontend:

Added "Unanswered Questions" option to category sort dropdown
Included appropriate translations and admin settings
Files Modified:

[category.js](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Added unreplied to validSorts
[topics.js](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Implemented unreplied filtering and counting
[sort.tpl](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Added dropdown option
[post.tpl](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Added admin setting
[topic.json](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Added translation
[post.json](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) - Added admin translation
Testing
Leverages existing [Topics.filterUnrepliedTids()](https://zany-fortnight-7vr6qwjwxrj9h9qx.github.dev/) functionality
Maintains backward compatibility
Integrates seamlessly with existing sorting infrastructure
Impact
Professors and instructors can now easily filter category views to show only topics needing responses, improving their ability to provide timely help to students.