### PR TITLE
Feature: Anonymous Posting for NodeBB Users

### DIFF
--- a/ANONYMOUS_POSTING.md
+++ b/ANONYMOUS_POSTING.md
@@ -1,0 +1,147 @@
+# Anonymous Posting Feature
+
+## Overview
+This feature allows NodeBB users to post topics and replies anonymously. When a post is marked as anonymous, the author's username is hidden and replaced with "Anonymous".
+
+## Implementation Details
+
+### Backend Changes
+
+#### 1. Post Creation (`src/posts/create.js`)
+- Added support for `anonymous` field in post data
+- When `data.anonymous` is truthy, the post is stored with `anonymous: 1` in the database
+
+#### 2. Post Data Structure (`src/posts/data.js`)
+- Added `anonymous` to the list of integer fields
+- Ensures the anonymous flag is properly parsed from the database
+
+#### 3. Post Display (`src/posts/summary.js`)
+- Added `anonymous` to the fields retrieved when getting post summaries
+- Modified post processing to replace user information with anonymous data when `post.anonymous === 1`
+- Anonymous posts display:
+  - Username: "Anonymous"
+  - Display name: "Anonymous"
+  - User slug: "anonymous"
+  - UID: 0 (guest)
+  - No profile picture
+  - Status: offline
+
+### API Usage
+
+To create an anonymous post, include the `anonymous` field in the post data:
+
+#### Anonymous Topic
+```javascript
+POST /api/v3/topics
+{
+  "cid": 1,
+  "title": "My Anonymous Question",
+  "content": "I have a question but want to remain anonymous",
+  "anonymous": true
+}
+```
+
+#### Anonymous Reply
+```javascript
+POST /api/v3/topics/:tid
+{
+  "content": "This is my anonymous reply",
+  "anonymous": true
+}
+```
+
+### Testing
+
+A comprehensive test suite has been added in `test/anonymous-posts.js` that verifies:
+1. Anonymous topics can be created
+2. Anonymous replies can be created
+3. Anonymous posts display "Anonymous" as the username
+4. Non-anonymous posts continue to display the actual username
+
+Run the tests with:
+```bash
+npm test -- --grep "Anonymous Posts"
+```
+
+## Future Enhancements
+
+### UI Integration
+To make this feature user-friendly, the following UI enhancements should be added:
+
+1. **Composer Checkbox**
+   - Add a checkbox in the composer (post/reply form) to allow users to opt-in to anonymous posting
+   - Label: "Post anonymously"
+   - This would require modifying the composer plugin or creating a custom plugin
+
+2. **Visual Indicators**
+   - Add an icon or badge to anonymous posts in topic lists and post views
+   - Help users understand which posts are anonymous
+
+3. **User Settings**
+   - Allow users to set a preference for default anonymous posting behavior
+   - Add option to always post anonymously in certain categories
+
+4. **Moderation Tools**
+   - Add ability for moderators/admins to reveal the true author of anonymous posts
+   - Store the original UID securely while displaying anonymously
+
+### Security Considerations
+
+1. **True Author Tracking**
+   - The current implementation preserves the original `uid` in the database
+   - This allows moderators to track who made anonymous posts if needed
+   - Consider adding a `originalUid` field for better separation
+
+2. **Abuse Prevention**
+   - Consider adding rate limiting for anonymous posts
+   - Allow categories to disable anonymous posting
+   - Add reputation requirements for anonymous posting
+
+3. **Privacy**
+   - Ensure anonymous posts don't leak user information through other metadata
+   - Review notification systems to avoid revealing anonymous poster identity
+   - Check if voting/reactions preserve anonymity
+
+## Files Modified
+
+1. `src/posts/create.js` - Added anonymous flag storage
+2. `src/posts/data.js` - Added anonymous to integer fields
+3. `src/posts/summary.js` - Added anonymous user display logic
+4. `test/anonymous-posts.js` - Added comprehensive test suite
+
+## Database Schema
+
+No database migration is required. The `anonymous` field is stored as an integer (0 or 1) in the post object in Redis/MongoDB:
+
+```
+post:<pid> {
+  pid: <number>,
+  uid: <number>,  // Original author UID (preserved)
+  content: <string>,
+  anonymous: 1,   // NEW: 1 for anonymous, 0 or undefined for normal
+  ...
+}
+```
+
+## Usage Example
+
+```javascript
+// Create an anonymous topic programmatically
+const topics = require('./src/topics');
+
+const result = await topics.post({
+  uid: userId,
+  cid: categoryId,
+  title: 'My Anonymous Question',
+  content: 'This is posted anonymously',
+  anonymous: true  // Enable anonymous mode
+});
+
+// Result will have anonymous flag set
+console.log(result.postData.anonymous); // 1
+
+// When retrieved, user info will show as Anonymous
+const posts = require('./src/posts');
+const postSummary = await posts.getPostSummaryByPids([result.postData.pid], userId, {});
+console.log(postSummary[0].user.username); // "Anonymous"
+```

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -39,6 +39,9 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+		if (data.anonymous) {
+			postData.anonymous = 1;
+		}
 		if (_activitypub) {
 			if (_activitypub.url) {
 				postData.url = _activitypub.url;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'anonymous',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -22,7 +22,7 @@ module.exports = function (Posts) {
 		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);
@@ -53,6 +53,19 @@ module.exports = function (Posts) {
 			post.user = uidToUser[post.uid];
 			Posts.overrideGuestHandle(post, post.handle);
 			post.handle = undefined;
+
+			// Override user info for anonymous posts
+			if (post.anonymous === 1) {
+				post.user = {
+					uid: 0,
+					username: 'Anonymous',
+					userslug: 'anonymous',
+					picture: '',
+					status: 'offline',
+					displayname: 'Anonymous',
+				};
+			}
+
 			post.topic = tidToTopic[post.tid];
 			post.category = post.topic && cidToCategory[post.topic.cid];
 			post.isMainPost = post.topic && post.pid === post.topic.mainPid;

--- a/test/anonymous-posts.js
+++ b/test/anonymous-posts.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const assert = require('assert');
+const db = require('./mocks/databasemock');
+
+const topics = require('../src/topics');
+const posts = require('../src/posts');
+const categories = require('../src/categories');
+const user = require('../src/user');
+
+describe('Anonymous Posts', () => {
+	let categoryObj;
+	let adminUid;
+
+	before(async () => {
+		adminUid = await user.create({ username: 'admin', password: '123456' });
+		categoryObj = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for anonymous posts',
+		});
+	});
+
+	it('should create an anonymous topic post', async () => {
+		const result = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Anonymous Topic',
+			content: 'This is an anonymous topic post',
+			anonymous: true,
+		});
+
+		assert.ok(result.postData);
+		assert.ok(result.topicData);
+		assert.strictEqual(result.postData.anonymous, 1);
+	});
+
+	it('should create an anonymous reply', async () => {
+		const topicResult = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Test Topic for Anonymous Reply',
+			content: 'Main post content',
+		});
+
+		const replyResult = await topics.reply({
+			uid: adminUid,
+			tid: topicResult.topicData.tid,
+			content: 'This is an anonymous reply',
+			anonymous: true,
+		});
+
+		assert.ok(replyResult);
+		assert.strictEqual(replyResult.anonymous, 1);
+	});
+
+	it('should display "Anonymous" as the username for anonymous posts', async () => {
+		const topicResult = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Anonymous Display Test',
+			content: 'Test anonymous user display',
+			anonymous: true,
+		});
+
+		const postSummary = await posts.getPostSummaryByPids([topicResult.postData.pid], adminUid, {});
+		assert.ok(postSummary[0]);
+		assert.strictEqual(postSummary[0].user.username, 'Anonymous');
+		assert.strictEqual(postSummary[0].user.displayname, 'Anonymous');
+		assert.strictEqual(postSummary[0].user.uid, 0);
+	});
+
+	it('should not display "Anonymous" for non-anonymous posts', async () => {
+		const topicResult = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Non-Anonymous Test',
+			content: 'Test non-anonymous user display',
+			anonymous: false,
+		});
+
+		const postSummary = await posts.getPostSummaryByPids([topicResult.postData.pid], adminUid, {});
+		assert.ok(postSummary[0]);
+		assert.notStrictEqual(postSummary[0].user.username, 'Anonymous');
+		assert.strictEqual(postSummary[0].user.username, 'admin');
+	});
+});


### PR DESCRIPTION
## Overview
Implements anonymous posting functionality to allow users to post topics and replies without revealing their identity. This addresses the user story: "As a more timid NodeBB user, I want to post anonymously so that I do not feel embarrassed for asking a question I have."

## Changes Made

### Backend Implementation
- **Post Creation** (`src/posts/create.js`): Added support for `anonymous` flag in post data
- **Data Structure** (`src/posts/data.js`): Added `anonymous` to integer fields for proper database parsing
- **Display Logic** (`src/posts/summary.js`): Modified to show "Anonymous" user information for anonymous posts

### Key Features
✅ Posts can be marked as anonymous via API  
✅ Anonymous posts display username as "Anonymous"  
✅ Original author UID preserved for moderation  
✅ Works for both topics and replies  
✅ Fully backward compatible  

### Testing
- Added comprehensive test suite in `test/anonymous-posts.js`
- All 4 tests passing:
  - Anonymous topic creation
  - Anonymous reply creation
  - User display verification
  - Non-anonymous posts unaffected

### Documentation
- Created `ANONYMOUS_POSTING.md` with:
  - Feature overview and usage
  - API documentation
  - Implementation details
  - Future enhancement suggestions
  - Security considerations

## API Usage

**Anonymous Topic:**
```javascript
POST /api/v3/topics
{
  "cid": 1,
  "title": "My Question",
  "content": "I want to ask anonymously",
  "anonymous": true
}