### PR TITLE
Add post pin/unpin functionality (instructor pin support)

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -29,6 +29,9 @@ define('forum/topic/events', [
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 
+		'event:post_pinned': onPostPinned,
+		'event:post_unpinned': onPostPinned,
+
 		'event:topic_moved': onTopicMoved,
 
 		'event:post_edited': onPostEdited,
@@ -257,6 +260,19 @@ define('forum/topic/events', [
 		if (data && data.tid && String(data.tid) === String(tid)) {
 			socket.emit('topics.markTopicNotificationsRead', [tid]);
 		}
+	}
+
+	function onPostPinned(data) {
+		if (!data || !data.pid || String(data.tid) !== String(ajaxify.data.tid)) {
+			return;
+		}
+		const postEl = components.get('post', 'pid', data.pid);
+		if (!postEl.length) {
+			return;
+		}
+		const isPinned = !!data.pinned;
+		postEl.toggleClass('pinned', isPinned);
+		hooks.fire('action:posts.pinned', data);
 	}
 
 	return Events;

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -129,6 +129,20 @@ define('forum/topic/postTools', [
 			return bookmarkPost($(this), getData($(this), 'data-pid'));
 		});
 
+		postContainer.on('click', '[component="post/pin"]', function () {
+			const pid = getData($(this), 'data-pid');
+			api.put(`/posts/${encodeURIComponent(pid)}/pin`).then(() => {
+				hooks.fire('action:post.pin', { pid });
+			}).catch(alerts.error);
+		});
+
+		postContainer.on('click', '[component="post/unpin"]', function () {
+			const pid = getData($(this), 'data-pid');
+			api.del(`/posts/${encodeURIComponent(pid)}/unpin`).then(() => {
+				hooks.fire('action:post.unpin', { pid });
+			}).catch(alerts.error);
+		});
+
 		postContainer.on('click', '[component="post/upvote"]', function () {
 			return votes.toggleVote($(this), '.upvoted', 1);
 		});

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -332,6 +332,30 @@ postsAPI.move = async function (caller, data) {
 	}
 };
 
+postsAPI.pin = async function (caller, data) {
+	if (!caller.uid) {
+		throw new Error('[[error:not-logged-in]]');
+	}
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const post = await posts.tools.pin(caller.uid, data.pid);
+	websockets.in(`topic_${post.tid}`).emit('event:post_pinned', post);
+	return post;
+};
+
+postsAPI.unpin = async function (caller, data) {
+	if (!caller.uid) {
+		throw new Error('[[error:not-logged-in]]');
+	}
+	if (!data || !data.pid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	const post = await posts.tools.unpin(caller.uid, data.pid);
+	websockets.in(`topic_${post.tid}`).emit('event:post_unpinned', post);
+	return post;
+};
+
 postsAPI.upvote = async function (caller, data) {
 	return await apiHelpers.postCommand(caller, 'upvote', 'voted', 'notifications:upvoted-your-post-in', data);
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -205,6 +205,16 @@ Posts.editQueuedPost = async (req, res) => {
 	helpers.formatApiResponse(200, res, result);
 };
 
+Posts.pin = async (req, res) => {
+	const post = await api.posts.pin(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res, post);
+};
+
+Posts.unpin = async (req, res) => {
+	const post = await api.posts.unpin(req, { pid: req.params.pid });
+	helpers.formatApiResponse(200, res, post);
+};
+
 Posts.notifyQueuedPostOwner = async (req, res) => {
 	const { id } = req.params;
 	await api.posts.notifyQueuedPostOwner(req, { id, message: req.body.message });

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -34,6 +34,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
+	setupApiRoute(router, 'put', '/:pid/pin', middlewares, controllers.write.posts.pin);
+	setupApiRoute(router, 'delete', '/:pid/unpin', middlewares, controllers.write.posts.unpin);
+
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -19,7 +19,7 @@ module.exports = function (SocketPosts) {
 		}
 		const cid = await posts.getCidByPid(data.pid);
 		const results = await utils.promiseParallel({
-			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url']),
+			posts: posts.getPostFields(data.pid, ['deleted', 'bookmarks', 'uid', 'ip', 'flagId', 'url', 'pinned']),
 			isAdmin: user.isAdministrator(socket.uid),
 			isGlobalMod: user.isGlobalModerator(socket.uid),
 			isModerator: user.isModerator(socket.uid, cid),
@@ -46,6 +46,8 @@ module.exports = function (SocketPosts) {
 		postData.display_flag_tools = socket.uid && results.canFlag.flag;
 		postData.display_moderator_tools = postData.display_edit_tools || postData.display_delete_tools;
 		postData.display_move_tools = results.isAdmin || results.isModerator;
+		// allow pin/unpin tools for category admins/mods (interpreting "instructor" as moderator role)
+		postData.display_pin_tools = results.isModerator || results.isAdmin;
 		postData.display_change_owner_tools = results.isAdmin || results.isModerator;
 		postData.display_manage_editors_tools = results.isAdmin || results.isModerator || postData.selfPost;
 		postData.display_ip_ban = (results.isAdmin || results.isGlobalMod) && !postData.selfPost;

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -4,6 +4,18 @@
 		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-pencil"></i></span> [[topic:edit]]
 	</a>
 </li>
+{{{ if posts.display_pin_tools }}}
+<li {{{ if posts.pinned }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/pin" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack"></i></span> [[topic:pin-post]]
+	</a>
+</li>
+<li {{{ if !posts.pinned }}}hidden{{{ end }}}>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/unpin" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-thumb-tack fa-rotate-90"></i></span> [[topic:unpin-post]]
+	</a>
+</li>
+{{{ end }}}
 {{{ if posts.display_delete_tools }}}
 <li {{{ if posts.deleted }}}hidden{{{ end }}}>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/delete" role="menuitem" href="#" class="{{{ if posts.deleted }}}hidden{{{ end }}}">


### PR DESCRIPTION
**Summary**

Implements pin/unpin for individual posts so instructors can highlight important questions.

Adds server-side tools, API endpoints, controller actions, socket payloads, template entries, and client handlers to allow pinning/unpinning from the post menu.

Emits realtime events so the UI can react when a post is pinned or unpinned.

**Why User Story #3:** instructors need the ability to pin posts/questions so students can see important information. This feature mirrors existing topic pin behaviour but scoped to posts.


**Changes**
Server
- Added pin/unpin helpers for posts:
  - tools.js — new `Posts.tools.pin` / `Posts.tools.unpin` that set `post.pinned` and log an event.
- API:
  - posts.js — new `postsAPI.pin` and `postsAPI.unpin` endpoints (call post tools and emit websocket events).
- Controllers:
  - posts.js — added HTTP handlers `Posts.pin` and `Posts.unpin` that forward to the API.

Socket / payloads
- tools.js — included `pinned` in the post fields returned for post tools and added `display_pin_tools` flag for callers who are category admin/mod.

Templates / client
- post-menu-list.tpl — added pin/unpin menu items (conditionally shown when `posts.display_pin_tools` is true).
- postTools.js — added click handlers that call:
  - PUT /api/v3/posts/:pid/pin
  - DELETE /api/v3/posts/:pid/unpin
  and fire client hooks `action:post.pin` / `action:post.unpin`.

Realtime events
- Emits `event:post_pinned` and `event:post_unpinned` to `topic_{tid}` room after pin/unpin.

Files changed (high level)
- tools.js — implement pin/unpin tool functions
- posts.js — add postsAPI.pin/unpin
- posts.js — add controller endpoints
- tools.js — include `pinned` and `display_pin_tools`
- post-menu-list.tpl — add pin/unpin menu items
- postTools.js — client handlers for pin/unpin

Contract (inputs / outputs / error modes)
- Inputs: pid (post id) sent via controller/API (HTTP PUT for pin, DELETE for unpin).
- Outputs: updated post object (includes `pinned` boolean) and websocket event to `topic_{tid}`.
- Errors: returns `[[error:invalid-data]]`, `[[error:no-post]]`, or `[[error:no-privileges]]` when the actor is not allowed.

Assumptions and decisions
- "Instructor" is treated as a category admin/moderator for privileges. If you want to use a dedicated "instructor" group/permission, I can rework the privilege check to target a specific group/permission.
- No DB schema changes required — `post:<pid>` objects gain a `pinned` field (stored in the same object).
- Pin expiry and ordering of pinned posts were intentionally left out (we can add pin expiry and pinned-ordering like topics in a follow-up).

Edge cases considered
- Non-existent pid => error.
- Caller without appropriate privileges => error.
- Pinning a scheduled topic/post is not applicable here; pinning checks are applied at category admin/mod level.

How to test locally
1. Start your NodeBB instance (or dev server) as you normally do.
2. As a user with category admin/mod privileges (our "instructor" assumption), open a topic and open a post’s menu.
3. Click “Pin post” — the API call should succeed and the post object `pinned` should be set to true and `event:post_pinned` will be broadcast to the topic room.
4. Click “Unpin post” — likewise should set `pinned` to false and emit `event:post_unpinned`.

Quick API test (example)
- Pin:
```bash
# authenticated request (replace cookies / token as appropriate)
curl -X PUT -H "Content-Type: application/json" -b "connect.sid=..." "http://localhost:4567/api/v3/posts/123/pin"
```
- Unpin:
```bash
curl -X DELETE -b "connect.sid=..." "http://localhost:4567/api/v3/posts/123/unpin"
```

Quality gates & notes
- Edits fixed the immediate lint issues reported during development patches. I did not run the full test suite in this run.
- Please run:
  - npm test (project test suite)
  - npm run lint (linting)
  - Smoke test in browser (pin/unpin flows and realtime propagation)

Requirements coverage
- Allow instructors to pin posts: Done (mapped to category admin/mod privileges — see assumptions).
- Realtime notification/UI update: Done (emits `event:post_pinned` / `event:post_unpinned`).
- Minimal UI: Done (menu items and client handlers). Visual indicator of pinned posts (icon/badge) is left as a small follow-up.

Follow-ups / TODOs
- Add visual pinned indicator in post template (e.g., an icon in post header) and styling.
- Add translation strings for `topic:pin-post` and `topic:unpin-post` (I used those keys in templates).
- Add unit/integration tests for postsAPI.pin/unpin and posts.tools.pin/unpin.
- Add pin expiry and pinned-order management (if needed).
- If instructors should be a separate permission/group, update privilege checks accordingly.

