### PR TITLE
feat(identification): add rank storage, admin sockets, whitelist and avatar badge

### DIFF
--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -320,6 +320,13 @@ module.exports = function (utils, Benchpress, relative_path) {
 			output += `<img${attr2String(attributes)} alt="${userObj.displayname}" loading="lazy" component="${component || 'avatar/picture'}" src="${userObj.picture}" style="${styles.join(' ')}" onError="this.remove()" itemprop="image" />`;
 		}
 		output += `<span${attr2String(attributes)} component="${component || 'avatar/icon'}" style="${styles.join(' ')} background-color: ${userObj['icon:bgColor']}">${userObj['icon:text']}</span>`;
+
+		// Identification rank badge
+		if (userObj['identification:rank']) {
+			const rank = userObj['identification:rank'];
+			const badgeStyle = `display:inline-block;margin-left:6px;padding:2px 6px;border-radius:10px;font-size:0.7em;color:${rank.textColor || '#fff'};background:${rank.color || '#000'};vertical-align:middle;`;
+			output += `<span class="identification-badge" title="${rank.name || ''}" style="${badgeStyle}">${rank.name || ''}</span>`;
+		}
 		return output;
 	}
 

--- a/src/identification/index.js
+++ b/src/identification/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const db = require('../database');
+
+const Identification = module.exports;
+
+// Store ranks as sorted set of slugs and objects at identification:rank:<slug>
+Identification.getRanks = async function () {
+	const keys = await db.getSortedSetRange('identification:ranks', 0, -1);
+	const objs = await db.getObjects(keys.map(k => `identification:rank:${k}`));
+	return objs.filter(Boolean);
+};
+
+Identification.getRank = async function (slug) {
+	return await db.getObject(`identification:rank:${slug}`);
+};
+
+Identification.saveRank = async function (rank) {
+	// rank should include slug
+	if (!rank || !rank.slug) {
+		throw new Error('Invalid rank');
+	}
+	await db.setObject(`identification:rank:${rank.slug}`, rank);
+	// ensure present in set
+	await db.sortedSetAdd('identification:ranks', [rank.slug], [rank.slug]);
+	return rank;
+};
+
+Identification.deleteRank = async function (slug) {
+	await db.delete(`identification:rank:${slug}`);
+	await db.sortedSetRemove('identification:ranks', [slug]);
+};

--- a/src/socket.io/admin.js
+++ b/src/socket.io/admin.js
@@ -31,6 +31,7 @@ SocketAdmin.logs = require('./admin/logs');
 SocketAdmin.errors = require('./admin/errors');
 SocketAdmin.digest = require('./admin/digest');
 SocketAdmin.cache = require('./admin/cache');
+SocketAdmin.identification = require('./admin/identification');
 
 SocketAdmin.before = async function (socket, method) {
 	const isAdmin = await user.isAdministrator(socket.uid);

--- a/src/socket.io/admin/identification.js
+++ b/src/socket.io/admin/identification.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const identification = require('../../identification');
+
+const IdentificationAdmin = module.exports;
+
+IdentificationAdmin.getRanks = async function () {
+	return await identification.getRanks();
+};
+
+IdentificationAdmin.saveRank = async function (socket, rank) {
+	if (!rank) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	await identification.saveRank(rank);
+	return rank;
+};
+
+IdentificationAdmin.deleteRank = async function (socket, slug) {
+	if (!slug) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	await identification.deleteRank(slug);
+};
+
+require('../../promisify')(IdentificationAdmin);

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -27,6 +27,8 @@ module.exports = function (User) {
 		'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
 		'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
 		'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason',
+		// identification tags: will contain an object like { name, color, textColor, slug }
+		'identification:rank',
 	];
 
 	let customFieldWhiteList = null;


### PR DESCRIPTION
Add server-side identification rank storage ([index.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/)).
Add admin socket handlers ([identification.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/)) and register them in [admin.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/).
Expose identification:rank in the user field whitelist ([data.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/)).
Render small rank badge in avatar helper when identification:rank is present ([helpers.common.js](https://zany-enigma-6999xjjx549qc54qp.github.dev/)).
This implements the backend plumbing and avatar rendering for issue #126; admin UI for managing ranks will follow in a separate PR.