### PR TITLE
Add support for audience-based topic pinning (students/instructors/all)

### DIFF
--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -27,15 +27,35 @@ module.exports = function (Posts) {
 		return cids;
 	};
 
-	Posts.filterPidsByCid = async function (pids, cid) {
+	Posts.filterPidsByCid = async function (pids, cid, uid) {
 		if (!cid) {
 			return pids;
 		}
 
 		if (!Array.isArray(cid) || cid.length === 1) {
-			return await filterPidsBySingleCid(pids, cid);
+			const filtered = await filterPidsBySingleCid(pids, cid);
+
+			// Extra step: filter by pinAudience if applicable
+			const postData = await Posts.getPostsFields(filtered, ['tid']);
+			const tids = _.uniq(postData.map(post => post && post.tid).filter(Boolean));
+			const topicData = await topics.getTopicsFields(tids, ['cid', 'pinAudience']);
+
+			// Determine user’s role
+			const isStudent = await db.isMemberOfGroup(uid, 'students'); // adjust depending on your helpers
+			const isInstructor = await db.isMemberOfGroup(uid, 'instructors');
+
+			return filtered.filter((pid, idx) => {
+				const t = topicData.find(t => t.cid === cid && t.tid === postData[idx].tid);
+				if (!t || !t.pinAudience) return true; // default visible
+				const audience = JSON.parse(t.pinAudience);
+				if (audience.includes('all')) return true;
+				if (isStudent && audience.includes('students')) return true;
+				if (isInstructor && audience.includes('instructors')) return true;
+				return false;
+			});
 		}
-		const pidsArr = await Promise.all(cid.map(c => Posts.filterPidsByCid(pids, c)));
+
+		const pidsArr = await Promise.all(cid.map(c => Posts.filterPidsByCid(pids, c, uid)));
 		return _.union(...pidsArr);
 	};
 

--- a/src/upgrades/1.15.0/add_target_uid_to_flags.js
+++ b/src/upgrades/1.15.0/add_target_uid_to_flags.js
@@ -10,28 +10,38 @@ module.exports = {
 	method: async function () {
 		const { progress } = this;
 
-		await batch.processSortedSet('flags:datetime', async (flagIds) => {
-			progress.incr(flagIds.length);
-			const flagData = await db.getObjects(flagIds.map(id => `flag:${id}`));
-			for (const flagObj of flagData) {
-				/* eslint-disable no-await-in-loop */
-				if (flagObj) {
-					const { targetId } = flagObj;
-					if (targetId) {
-						if (flagObj.type === 'post') {
+		await batch.processSortedSet(
+			'flags:datetime',
+			async (flagIds) => {
+				progress.incr(flagIds.length);
+				const flagData = await db.getObjects(
+					flagIds.map(id => `flag:${id}`)
+				);
+
+				// Collect async operations
+				const ops = flagData
+					.filter(flagObj => flagObj && flagObj.targetId)
+					.map(async (flagObj) => {
+						const { targetId, type, flagId } = flagObj;
+
+						if (type === 'post') {
 							const targetUid = await posts.getPostField(targetId, 'uid');
-							if (targetUid) {
-								await db.setObjectField(`flag:${flagObj.flagId}`, 'targetUid', targetUid);
-							}
-						} else if (flagObj.type === 'user') {
-							await db.setObjectField(`flag:${flagObj.flagId}`, 'targetUid', targetId);
+							if (!targetUid) return;
+							return db.setObjectField(`flag:${flagId}`, 'targetUid', targetUid);
 						}
-					}
-				}
+
+						if (type === 'user') {
+							return db.setObjectField(`flag:${flagId}`, 'targetUid', targetId);
+						}
+					});
+
+				// Run all in parallel
+				await Promise.all(ops);
+			},
+			{
+				progress,
+				batch: 500,
 			}
-		}, {
-			progress: progress,
-			batch: 500,
-		});
+		);
 	},
 };

--- a/src/upgrades/1.15.0/add_target_uid_to_flags.js
+++ b/src/upgrades/1.15.0/add_target_uid_to_flags.js
@@ -11,7 +11,7 @@ module.exports = {
 		const { progress } = this;
 
 		await batch.processSortedSet(
-			'flags:datetime',
+			'flags:datetime'
 			async (flagIds) => {
 				progress.incr(flagIds.length);
 				const flagData = await db.getObjects(

--- a/src/upgrades/5.0.0/add_pin_to_audience_to_topics.js
+++ b/src/upgrades/5.0.0/add_pin_to_audience_to_topics.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const db = require('../../database');
+
+module.exports = {
+	name: 'Add pinAudience field to topics',
+	timestamp: Date.UTC(2025, 9, 29),
+	method: async function () {
+		const { progress } = this;
+
+		// Get all topic IDs
+		const tids = await db.getSortedSetRange('topics:tid', 0, -1);
+		progress.total = tids.length;
+
+		for (const tid of tids) {
+			// Default pinAudience = 'all' for backwards compatibility
+			await db.setObjectField(`topic:${tid}`, 'pinAudience', 'all');
+			progress.incr();
+		}
+	},
+};


### PR DESCRIPTION
Adam Sultan, Josh Dong
This PR introduces audience-specific pinning for topics, allowing instructors to control which groups see pinned announcements at the top of a category.

🔑 Key Changes
	•	Backend (topics.js)
	•	Added pinAudience field to topics (default: "all").
	•	Updated togglePin, setPinExpiry, and checkPinExpiry to respect pinAudience.
	•	Posts/Category filtering
	•	Ensures pinned topics only appear for the intended audience (students, instructors, or all).
	•	API (topicsAPI)
	•	Extended topicsAPI.pin to accept pinAudience alongside expiry.
	•	Updated topicsAPI.get to always return a pinAudience field.
	•	Updated topicsAPI.unpin to clear pinAudience when a topic is unpinned.
	•	Migration
	•	New migration script sets pinAudience = 'all' for existing topics to preserve backwards compatibility.

✅ Example Usage
POST /api/v3/topics/pin
{
  "tids": [123],
  "expiry": 1738300000000,
  "pinAudience": "students"
}

	"all" → pinned for everyone (default behavior)
	•	"students" → only students see the pin
	•	"instructors" → only instructors/mods/admins see the pin

🧪 Next Steps
	•	Add UI dropdown in topic tools to set audience (All, Students, Instructors).
	•	Extend test coverage to ensure pinned filtering works across audiences.

