### PR TITLE
Add category-scoped title-only search provider (fixes #128)

### DIFF
--- a/src/categories/index.js
+++ b/src/categories/index.js
@@ -24,6 +24,8 @@ require('./recentreplies')(Categories);
 require('./update')(Categories);
 require('./watch')(Categories);
 require('./search')(Categories);
+// Basic category-scoped search provider (returns tids filtered by title when a query is provided)
+require('./search-provider');
 
 Categories.icons = require('./icon');
 

--- a/src/categories/search-provider.js
+++ b/src/categories/search-provider.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const db = require('../database');
+const topics = require('../topics');
+const plugins = require('../plugins');
+const meta = require('../meta');
+
+// Register a hook that provides a minimal, safe category-scoped search.
+// It filters topic tids by matching the search term against topic titles.
+plugins.hooks.register('core', {
+	hook: 'filter:categories.getTopicIds',
+	method: async function (payload) {
+		try {
+			const data = payload.data || {};
+			const { cid } = data;
+			const queryObj = data.query || data.q || '';
+
+			let term = '';
+			if (!queryObj) {
+				term = '';
+			} else if (typeof queryObj === 'string') {
+				term = queryObj;
+			} else if (typeof queryObj === 'object') {
+				term = queryObj.term || queryObj.search || queryObj.q || queryObj.query || '';
+			}
+
+			term = String(term || '').trim();
+			if (!term || term.length < 2) {
+				// Not a meaningful search; don't modify payload
+				return payload;
+			}
+
+			const sort = data.sort || (data.settings && data.settings.categoryTopicSort) || meta.config.categoryTopicSort || 'recently_replied';
+			const sortToSet = {
+				recently_replied: `cid:${cid}:tids`,
+				recently_created: `cid:${cid}:tids:create`,
+				most_posts: `cid:${cid}:tids:posts`,
+				most_votes: `cid:${cid}:tids:votes`,
+				most_views: `cid:${cid}:tids:views`,
+			};
+
+			const mainSet = sortToSet.hasOwnProperty(sort) ? sortToSet[sort] : `cid:${cid}:tids`;
+			const pinnedSet = `cid:${cid}:tids:pinned`;
+
+			const allTids = await db.getSortedSetRange([pinnedSet, mainSet], 0, -1);
+			if (!Array.isArray(allTids) || !allTids.length) {
+				payload.tids = [];
+				return payload;
+			}
+
+			const topicFields = await topics.getTopicsFields(allTids, ['title']);
+			const tokens = term.toLowerCase().split(/\s+/).filter(Boolean);
+			const matchWords = data.matchWords || 'all';
+
+			const matched = allTids.filter((tid, idx) => {
+				const t = (topicFields[idx] && topicFields[idx].title) ? String(topicFields[idx].title).toLowerCase() : '';
+				if (!t) {
+					return false;
+				}
+				if (matchWords === 'any') {
+					return tokens.some(tok => t.includes(tok));
+				}
+				return tokens.every(tok => t.includes(tok));
+			});
+
+			const start = typeof data.start === 'number' ? data.start : (typeof data.start === 'string' && data.start !== '' ? parseInt(data.start, 10) : 0);
+			const stop = typeof data.stop === 'number' ? data.stop : (typeof data.stop === 'string' && data.stop !== '' ? parseInt(data.stop, 10) : Math.max(0, matched.length - 1));
+			const sliced = matched.slice(start, stop === -1 ? undefined : stop + 1);
+
+			payload.tids = sliced;
+			return payload;
+		} catch (err) {
+			// Avoid breaking category listing on errors
+			return payload;
+		}
+	},
+});

--- a/tools/smoke-category-search.js
+++ b/tools/smoke-category-search.js
@@ -1,0 +1,22 @@
+const Categories = require('../src/categories');
+
+async function run() {
+	// Simulate data for category 1
+	const data = {
+		cid: 1,
+		start: 0,
+		stop: 49,
+		uid: 1,
+		query: 'test',
+	};
+
+	try {
+		// Call the public function that ultimately fires filter:categories.getTopicIds
+		const tids = await Categories.getTopicIds(data);
+		console.log('Result tids:', tids);
+	} catch (err) {
+		console.error('Error in smoke test:', err);
+	}
+}
+
+run();


### PR DESCRIPTION
This PR implements a minimal, safe category-scoped search provider to satisfy issue #128.

Summary of changes
- Added src/categories/search-provider.js — registers a fallback `filter:categories.getTopicIds` hook that filters topic tids within a category by matching the search term against topic titles. It preserves pinned/topic ordering and respects paging (`data.start`/`data.stop`). The provider returns the original payload on error or when the term is too short, so it is fail-safe.

How to test
1. Lint: `npm run lint` — should produce no errors (only unrelated vendor warnings).
2. Start NodeBB: `npm start` (or your development startup sequence). Visit a category page and use the search bar to search within that category (term length >= 2).
3. Alternatively, run the smoke test locally: `node tools/smoke-category-search.js` to exercise the provider headlessly (prints returned tids or payload).