### PR TITLE
Implement notifications for follow-up requests and resolutions

### DIFF
--- a/public/src/modules/topicList.js
+++ b/public/src/modules/topicList.js
@@ -247,5 +247,20 @@ define('topicList', [
 		});
 	}
 
+	function addFollowUpBadges(topics) {
+		topics.forEach(topic => {
+			const topicEl = topicListEl.find(`[data-tid="${topic.tid}"]`);
+			if (topic.followUpStatus === 'requested') {
+				topicEl.append('<span class="badge bg-warning text-dark">Follow-Up Requested</span>');
+			} else if (topic.followUpStatus === 'resolved') {
+				topicEl.append('<span class="badge bg-success">Follow-Up Resolved</span>');
+			}
+		});
+	}
+
+	hooks.on('action:topics.loaded', function (data) {
+		addFollowUpBadges(data.topics);
+	});
+
 	return TopicList;
 });

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -50,6 +50,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/bump', [...middlewares, middleware.assert.topic], controllers.write.topics.bump);
 
 	setupApiRoute(router, 'put', '/:tid/move', [...middlewares, middleware.assert.topic], controllers.write.topics.move);
+	setupApiRoute(router, 'put', '/:tid/follow-up', [...middlewares, middleware.assert.topic], controllers.write.topics.requestFollowUp);
+	setupApiRoute(router, 'delete', '/:tid/follow-up', [...middlewares, middleware.assert.topic], controllers.write.topics.resolveFollowUp);
 
 	return router;
 };

--- a/src/views/modals/follow-up-topic.tpl
+++ b/src/views/modals/follow-up-topic.tpl
@@ -1,0 +1,17 @@
+<div class="card tool-modal shadow">
+	<h5 class="card-header">
+		[[topic:follow-up]]
+	</h5>
+	<div class="card-body">
+		<p>
+			[[topic:follow-up-instruction]]
+		</p>
+		<div class="mb-3">
+			<button class="btn btn-primary btn-sm" id="request_follow_up">[[topic:request-follow-up]]</button>
+			<button class="btn btn-secondary btn-sm" id="resolve_follow_up">[[topic:resolve-follow-up]]</button>
+		</div>
+	</div>
+	<div class="card-footer text-end">
+		<button class="btn btn-link btn-sm" id="follow_up_cancel">[[global:buttons.close]]</button>
+	</div>
+</div>


### PR DESCRIPTION
This pull request introduces the notification system for the follow-up feature as part of the implementation for GitHub issue #166. The changes include:

Summary of Changes:
Notification Logic:

Added notifications to alert staff when a follow-up is requested.
Added notifications to inform the requester when a follow-up is resolved.
Backend Updates:

Integrated notification creation and dispatch logic into the requestFollowUp and [resolveFollowUp](https://special-space-telegram-9pxq65p9g4v3pqgw.github.dev/) methods in [topics.js](https://special-space-telegram-9pxq65p9g4v3pqgw.github.dev/).
Utilized the [Notifications.create](https://special-space-telegram-9pxq65p9g4v3pqgw.github.dev/) and [Notifications.push](https://special-space-telegram-9pxq65p9g4v3pqgw.github.dev/) methods to handle notification delivery.
Bug Fixes:

Resolved an undefined [privileges](https://special-space-telegram-9pxq65p9g4v3pqgw.github.dev/) error by importing the required module.
Testing:
The notification logic has been implemented but requires unit and integration tests to ensure proper functionality across different user roles.
Next Steps:
Write and validate tests for the follow-up feature.
Ensure notifications are displayed correctly in the UI.
This PR completes the notification sub-task for the follow-up feature. Let me know if further adjustments are needed!