### PR TITLE
Refactor getUsersFromSet to use options object

### DIFF
--- a/src/user/index.js
+++ b/src/user/index.js
@@ -72,7 +72,7 @@ User.getUidsFromSet = async function (set, start, stop) {
 	return await db.getSortedSetRevRange(set, start, stop);
 };
 
-User.getUsersFromSet = async function (set, uid, start, stop) {
+User.getUsersFromSet = async function (set, {uid, start, stop}) {
 	const uids = await User.getUidsFromSet(set, start, stop);
 	return await User.getUsers(uids, uid);
 };


### PR DESCRIPTION
Replaces the 4 individual parameters (set, uid, start, stop) with a destructured options object (set, { uid, start, stop }) to resolve a qlty "function with many parameters" code smell. No logic was changed.