### PR TITLE
Reduce complexity of editMainPost() function

### DIFF
--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -103,6 +103,31 @@ module.exports = function (Posts) {
 		};
 	};
 
+	async function validateTagUpdate(data, topicData) {
+		const canTag = await privileges.categories.can('topics:tag', topicData.cid, data.uid);
+		if (!canTag) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await topics.validateTags(data.tags, topicData.cid, data.uid, data.pid);
+	}
+
+	function buildNewTopicData(data, postData, topicData, title) {
+		const { tid } = postData;
+		const isRescheduling = rescheduling(data, topicData);
+		const newTopicData = {
+			tid,
+			cid: topicData.cid,
+			uid: postData.uid,
+			mainPid: data.pid,
+			timestamp: isRescheduling ? data.timestamp : topicData.timestamp,
+		};
+		if (title) {
+			newTopicData.title = title;
+			newTopicData.slug = `${tid}/${slugify(title) || 'topic'}`;
+		}
+		return newTopicData;
+	}
+
 	async function editMainPost(data, postData, topicData) {
 		const { tid } = postData;
 		const title = data.title ? data.title.trim() : '';
@@ -110,7 +135,7 @@ module.exports = function (Posts) {
 		const isMain = String(data.pid) === String(topicData.mainPid);
 		if (!isMain) {
 			return {
-				tid: tid,
+				tid,
 				cid: topicData.cid,
 				title: topicData.title,
 				isMainPost: false,
@@ -119,41 +144,29 @@ module.exports = function (Posts) {
 			};
 		}
 
-		const newTopicData = {
-			tid: tid,
-			cid: topicData.cid,
-			uid: postData.uid,
-			mainPid: data.pid,
-			timestamp: rescheduling(data, topicData) ? data.timestamp : topicData.timestamp,
-		};
-		if (title) {
-			newTopicData.title = title;
-			newTopicData.slug = `${tid}/${slugify(title) || 'topic'}`;
-		}
-
 		const tagsupdated = Array.isArray(data.tags) &&
 			!_.isEqual(data.tags, topicData.tags.map(tag => tag.value));
 
 		if (tagsupdated) {
-			const canTag = await privileges.categories.can('topics:tag', topicData.cid, data.uid);
-			if (!canTag) {
-				throw new Error('[[error:no-privileges]]');
-			}
-			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
+			await validateTagUpdate(data, topicData);
 		}
+
+		const newTopicData = buildNewTopicData(data, postData, topicData, title);
+		const isRescheduling = rescheduling(data, topicData);
 
 		const results = await plugins.hooks.fire('filter:topic.edit', {
 			req: data.req,
 			topic: newTopicData,
-			data: data,
+			data,
 		});
 		await db.setObject(`topic:${tid}`, results.topic);
+
 		if (tagsupdated) {
 			await topics.updateTopicTags(tid, data.tags);
 		}
 		const tags = await topics.getTopicTagsObjects(tid);
 
-		if (rescheduling(data, topicData)) {
+		if (isRescheduling) {
 			await topics.scheduled.reschedule(newTopicData);
 		}
 
@@ -161,19 +174,20 @@ module.exports = function (Posts) {
 		newTopicData.oldTitle = topicData.title;
 		const renamed = title && translator.escape(validator.escape(String(title))) !== topicData.title;
 		plugins.hooks.fire('action:topic.edit', { topic: newTopicData, uid: data.uid });
+
 		return {
-			tid: tid,
+			tid,
 			cid: newTopicData.cid,
 			uid: postData.uid,
 			title: validator.escape(String(title)),
 			oldTitle: topicData.title,
 			slug: newTopicData.slug || topicData.slug,
 			isMainPost: true,
-			renamed: renamed,
-			tagsupdated: tagsupdated,
-			tags: tags,
+			renamed,
+			tagsupdated,
+			tags,
 			oldTags: topicData.tags,
-			rescheduled: rescheduling(data, topicData),
+			rescheduled: isRescheduling,
 		};
 	}
 


### PR DESCRIPTION
This _should_ fix a `qlty` smell reported `editMainPost()` being too complex. The code was copy-and-pasted from Claude Sonnet 4.6 on the web (not context aware). I have done minimal verification to check that the code is correct.