### PR TITLE
Refactor: fix duplicated code smell in test/topics.js

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -33,6 +33,21 @@ describe('Topic\'s', () => {
 	let csrf_token;
 	let fooUid;
 
+	function postTopicAndSetResults(done, callback) {
+		topics.post({
+			uid: topic.userId,
+			title: topic.title,
+			content: topic.content,
+			cid: topic.categoryId,
+		}, (err, result) => {
+			if (err) {
+				return done(err);
+			}
+			callback(result);
+			done();
+		});
+	}
+
 	before(async () => {
 		adminUid = await User.create({ username: 'admin', password: '123456' });
 		fooUid = await User.create({ username: 'foo' });
@@ -243,19 +258,9 @@ describe('Topic\'s', () => {
 		let newPost;
 
 		before((done) => {
-			topics.post({
-				uid: topic.userId,
-				title: topic.title,
-				content: topic.content,
-				cid: topic.categoryId,
-			}, (err, result) => {
-				if (err) {
-					return done(err);
-				}
-
+			postTopicAndSetResults(done, (result) => {
 				newTopic = result.topicData;
 				newPost = result.postData;
-				done();
 			});
 		});
 
@@ -381,19 +386,9 @@ describe('Topic\'s', () => {
 		let newPost;
 
 		before((done) => {
-			topics.post({
-				uid: topic.userId,
-				title: topic.title,
-				content: topic.content,
-				cid: topic.categoryId,
-			}, (err, result) => {
-				if (err) {
-					return done(err);
-				}
-
+			postTopicAndSetResults(done, (result) => {
 				newTopic = result.topicData;
 				newPost = result.postData;
-				done();
 			});
 		});
 


### PR DESCRIPTION
Extracted repeated topics.post() call in before() hooks into a shared helper function to eliminate code duplication flagged by qlty.

<img width="818" height="671" alt="Screenshot 2026-03-12 at 10 25 27 AM" src="https://github.com/user-attachments/assets/dc818674-c6eb-455a-98d5-912ec82f5ea2" />
