### PR TITLE
Reduce complexity of editMainPost() function

### DIFF
--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -109,14 +109,7 @@ module.exports = function (Posts) {
 
 		const isMain = String(data.pid) === String(topicData.mainPid);
 		if (!isMain) {
-			return {
-				tid: tid,
-				cid: topicData.cid,
-				title: topicData.title,
-				isMainPost: false,
-				renamed: false,
-				tagsupdated: false,
-			};
+			return buildNonMainReturn(tid, topicData);
 		}
 
 		const newTopicData = {
@@ -126,21 +119,10 @@ module.exports = function (Posts) {
 			mainPid: data.pid,
 			timestamp: rescheduling(data, topicData) ? data.timestamp : topicData.timestamp,
 		};
-		if (title) {
-			newTopicData.title = title;
-			newTopicData.slug = `${tid}/${slugify(title) || 'topic'}`;
-		}
 
-		const tagsupdated = Array.isArray(data.tags) &&
-			!_.isEqual(data.tags, topicData.tags.map(tag => tag.value));
+		await handleTitle(newTopicData, title, tid);
 
-		if (tagsupdated) {
-			const canTag = await privileges.categories.can('topics:tag', topicData.cid, data.uid);
-			if (!canTag) {
-				throw new Error('[[error:no-privileges]]');
-			}
-			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
-		}
+		const tagsupdated = await handleTags(data, topicData, tid);
 
 		const results = await plugins.hooks.fire('filter:topic.edit', {
 			req: data.req,
@@ -153,14 +135,55 @@ module.exports = function (Posts) {
 		}
 		const tags = await topics.getTopicTagsObjects(tid);
 
-		if (rescheduling(data, topicData)) {
-			await topics.scheduled.reschedule(newTopicData);
-		}
+		await handleRescheduling(data, topicData, newTopicData);
 
 		newTopicData.tags = data.tags;
 		newTopicData.oldTitle = topicData.title;
 		const renamed = title && translator.escape(validator.escape(String(title))) !== topicData.title;
 		plugins.hooks.fire('action:topic.edit', { topic: newTopicData, uid: data.uid });
+		return buildMainReturn(tid, newTopicData, postData, title, renamed, tagsupdated, tags, topicData, data);
+	}
+
+	function buildNonMainReturn(tid, topicData) {
+		return {
+			tid: tid,
+			cid: topicData.cid,
+			title: topicData.title,
+			isMainPost: false,
+			renamed: false,
+			tagsupdated: false,
+		};
+	}
+
+	async function handleTitle(newTopicData, title, tid) {
+		if (title) {
+			newTopicData.title = title;
+			newTopicData.slug = `${tid}/${slugify(title) || 'topic'}`;
+		}
+	}
+
+	async function handleTags(data, topicData, tid) {
+		const tagsupdated = Array.isArray(data.tags) &&
+			!_.isEqual(data.tags, topicData.tags.map(tag => tag.value));
+
+		if (tagsupdated) {
+			const canTag = await privileges.categories.can('topics:tag', topicData.cid, data.uid);
+			if (!canTag) {
+				throw new Error('[[error:no-privileges]]');
+			}
+			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
+		}
+
+		return tagsupdated;
+	}
+
+	async function handleRescheduling(data, topicData, newTopicData) {
+		if (rescheduling(data, topicData)) {
+			await topics.scheduled.reschedule(newTopicData);
+		}
+	}
+
+	function buildMainReturn(tid, newTopicData, postData, title, renamed, tagsupdated, tags, topicData, data) {
 		return {
 			tid: tid,
 			cid: newTopicData.cid,


### PR DESCRIPTION
## Description
This PR refactors the `editMainPost` function in `src/posts/edit.js` to reduce its cyclomatic complexity from 12 (as reported by qlty) to a more manageable level. The function was broken down into smaller, single-responsibility helper functions without altering the original behavior.

### Changes Made
- **Refactored `editMainPost`**: Split the monolithic function into modular helpers:
  - `buildNonMainReturn`: Handles return for non-main posts
  - `handleTitle`: Manages title and slug updates
  - `handleTags`: Validates and updates tags
  - `handleRescheduling`: Handles topic rescheduling logic
  - `buildMainReturn`: Constructs the return object for main posts
- **Improved Readability**: The main function now follows a linear flow, making it easier to understand and maintain.
- **No Functional Changes**: All existing logic is preserved; this is purely a structural refactor.

### Reason for Change
- **Code Quality**: Addresses the high complexity warning from qlty, improving code maintainability and reducing the risk of bugs.
- **Best Practices**: Aligns with clean code principles by adhering to the Single Responsibility Principle.
- **Testing**: Verified with existing test suite (`npm test -- --grep "edit"`), ensuring no regressions.

### Testing
- Ran ESLint on the modified file to confirm no linting issues.
- Executed relevant tests to validate functionality remains intact.
- No breaking changes introduced.