### PR TITLE
Refactor getUsersFromSet to use options object

### DIFF
--- a/src/user/index.js
+++ b/src/user/index.js
@@ -72,7 +72,8 @@ User.getUidsFromSet = async function (set, start, stop) {
 	return await db.getSortedSetRevRange(set, start, stop);
 };
 
-User.getUsersFromSet = async function (set, {uid, start, stop}) {
+User.getUsersFromSet = async function (options) {
+	const { set, uid, start, stop } = options;
 	const uids = await User.getUidsFromSet(set, start, stop);
 	return await User.getUsers(uids, uid);
 };

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -72,7 +72,7 @@ User.getUidsFromSet = async function (set, start, stop) {
 	return await db.getSortedSetRevRange(set, start, stop);
 };
 
-User.getUsersFromSet = async function (set, uid, start, stop) {
+User.getUsersFromSet = async function (set, {uid, start, stop}) {
 	const uids = await User.getUidsFromSet(set, start, stop);
 	return await User.getUsers(uids, uid);
 };


### PR DESCRIPTION
This PR addresses a code smell by refactoring the [getUsersFromSet] function in [index.js] to accept a single options object instead of four separate parameters. This improves readability and maintainability. All call sites have been updated accordingly to pass the parameters as an object. No functional changes were made.