### PR TITLE
Refactor auth route registration complexity

### DIFF
--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -63,97 +63,116 @@ Auth.verifyToken = async function (token, done) {
 	}
 };
 
-Auth.reloadRoutes = async function (params) {
-	loginStrategies.length = 0;
-	const { router } = params;
-
-	// Local Logins
+function registerLocalLoginStrategy() {
 	if (plugins.hooks.hasListeners('action:auth.overrideLogin')) {
 		winston.warn('[authentication] Login override detected, skipping local login strategy.');
 		plugins.hooks.fire('action:auth.overrideLogin');
-	} else {
-		passport.use(new passportLocal({ passReqToCallback: true }, controllers.authentication.localLogin));
+		return;
 	}
 
-	// HTTP bearer authentication
-	passport.use('core.api', new BearerStrategy({}, Auth.verifyToken));
+	passport.use(new passportLocal({ passReqToCallback: true }, controllers.authentication.localLogin));
+}
 
-	// Additional logins via SSO plugins
+async function loadLoginStrategies() {
 	try {
-		loginStrategies = await plugins.hooks.fire('filter:auth.init', loginStrategies);
+		return await plugins.hooks.fire('filter:auth.init', loginStrategies);
 	} catch (err) {
 		winston.error(`[authentication] ${err.stack}`);
+		return loginStrategies;
 	}
-	loginStrategies = loginStrategies || [];
-	loginStrategies.forEach((strategy) => {
-		if (strategy.url) {
-			router[strategy.urlMethod || 'get'](strategy.url, Auth.middleware.applyCSRF, async (req, res, next) => {
-				let opts = {
-					scope: strategy.scope,
-					prompt: strategy.prompt || undefined,
-				};
+}
 
-				if (strategy.checkState !== false) {
-					req.session.ssoState = generateToken(req, true);
-					opts.state = req.session.ssoState;
-				}
-				if (req.query.next) {
-					req.session.next = req.query.next;
-				}
+function registerStrategyAuthRoute(router, strategy) {
+	if (!strategy.url) {
+		return;
+	}
 
-				// Allow SSO plugins to override/append options (for use in passport prototype authorizationParams)
-				({ opts } = await plugins.hooks.fire('filter:auth.options', { req, res, opts }));
-				passport.authenticate(strategy.name, opts)(req, res, next);
-			});
+	router[strategy.urlMethod || 'get'](strategy.url, Auth.middleware.applyCSRF, async (req, res, next) => {
+		let opts = {
+			scope: strategy.scope,
+			prompt: strategy.prompt || undefined,
+		};
+
+		if (strategy.checkState !== false) {
+			req.session.ssoState = generateToken(req, true);
+			opts.state = req.session.ssoState;
+		}
+		if (req.query.next) {
+			req.session.next = req.query.next;
 		}
 
-		router[strategy.callbackMethod || 'get'](strategy.callbackURL, (req, res, next) => {
-			// Ensure the passed-back state value is identical to the saved ssoState (unless explicitly skipped)
-			if (strategy.checkState === false) {
-				return next();
+		// Allow SSO plugins to override/append options (for use in passport prototype authorizationParams)
+		({ opts } = await plugins.hooks.fire('filter:auth.options', { req, res, opts }));
+		passport.authenticate(strategy.name, opts)(req, res, next);
+	});
+}
+
+function validateCallbackState(strategy) {
+	return function (req, res, next) {
+		if (strategy.checkState === false) {
+			return next();
+		}
+
+		next(req.query.state !== req.session.ssoState ? new Error('[[error:csrf-invalid]]') : null);
+	};
+}
+
+function authenticateStrategyCallback(strategy) {
+	return function (req, res, next) {
+		// Trigger registration interstitial checks
+		req.session.registration = req.session.registration || {};
+		// save returnTo for later usage in /register/complete
+		// passport seems to remove `req.session.returnTo` after it redirects
+		req.session.registration.returnTo = req.session.next || req.session.returnTo;
+
+		passport.authenticate(strategy.name, (err, user) => {
+			if (err) {
+				if (req.session && req.session.registration) {
+					delete req.session.registration;
+				}
+				return next(err);
 			}
 
-			next(req.query.state !== req.session.ssoState ? new Error('[[error:csrf-invalid]]') : null);
-		}, (req, res, next) => {
-			// Trigger registration interstitial checks
-			req.session.registration = req.session.registration || {};
-			// save returnTo for later usage in /register/complete
-			// passport seems to remove `req.session.returnTo` after it redirects
-			req.session.registration.returnTo = req.session.next || req.session.returnTo;
-
-			passport.authenticate(strategy.name, (err, user) => {
-				if (err) {
-					if (req.session && req.session.registration) {
-						delete req.session.registration;
-					}
-					return next(err);
+			if (!user) {
+				if (req.session && req.session.registration) {
+					delete req.session.registration;
 				}
+				return helpers.redirect(res, strategy.failureUrl !== undefined ? strategy.failureUrl : '/login');
+			}
 
-				if (!user) {
-					if (req.session && req.session.registration) {
-						delete req.session.registration;
-					}
-					return helpers.redirect(res, strategy.failureUrl !== undefined ? strategy.failureUrl : '/login');
-				}
+			res.locals.user = user;
+			res.locals.strategy = strategy;
+			next();
+		})(req, res, next);
+	};
+}
 
-				res.locals.user = user;
-				res.locals.strategy = strategy;
-				next();
-			})(req, res, next);
-		}, Auth.middleware.validateAuth, (req, res, next) => {
-			async.waterfall([
-				async.apply(req.login.bind(req), res.locals.user, { keepSessionInfo: true }),
-				async.apply(controllers.authentication.onSuccessfulLogin, req, res.locals.user.uid),
-			], (err) => {
-				if (err) {
-					return next(err);
-				}
+function finishStrategyLogin(strategy) {
+	return function (req, res, next) {
+		async.waterfall([
+			async.apply(req.login.bind(req), res.locals.user, { keepSessionInfo: true }),
+			async.apply(controllers.authentication.onSuccessfulLogin, req, res.locals.user.uid),
+		], (err) => {
+			if (err) {
+				return next(err);
+			}
 
-				helpers.redirect(res, strategy.successUrl !== undefined ? strategy.successUrl : '/');
-			});
+			helpers.redirect(res, strategy.successUrl !== undefined ? strategy.successUrl : '/');
 		});
-	});
+	};
+}
 
+function registerStrategyCallbackRoute(router, strategy) {
+	router[strategy.callbackMethod || 'get'](
+		strategy.callbackURL,
+		validateCallbackState(strategy),
+		authenticateStrategyCallback(strategy),
+		Auth.middleware.validateAuth,
+		finishStrategyLogin(strategy)
+	);
+}
+
+function registerBaseAuthRoutes(router) {
 	const multipart = require('connect-multiparty');
 	const multipartMiddleware = multipart();
 	const middlewares = [multipartMiddleware, Auth.middleware.applyCSRF, Auth.middleware.applyBlacklist];
@@ -163,6 +182,24 @@ Auth.reloadRoutes = async function (params) {
 	router.post('/register/abort', middlewares, controllers.authentication.registerAbort);
 	router.post('/login', Auth.middleware.applyCSRF, Auth.middleware.applyBlacklist, controllers.authentication.login);
 	router.post('/logout', Auth.middleware.applyCSRF, controllers.authentication.logout);
+}
+
+Auth.reloadRoutes = async function (params) {
+	loginStrategies.length = 0;
+	const { router } = params;
+
+	registerLocalLoginStrategy();
+
+	passport.use('core.api', new BearerStrategy({}, Auth.verifyToken));
+
+	loginStrategies = await loadLoginStrategies();
+	loginStrategies = loginStrategies || [];
+	loginStrategies.forEach((strategy) => {
+		registerStrategyAuthRoute(router, strategy);
+		registerStrategyCallbackRoute(router, strategy);
+	});
+
+	registerBaseAuthRoutes(router);
 };
 
 passport.serializeUser((user, done) => {


### PR DESCRIPTION
> GENERATED PR:
## Summary
This PR refactors the authentication route setup to address the qlty smell for high function complexity in `reloadRoutes`.

## Problem
The function `reloadRoutes` in [src/routes/authentication.js](src/routes/authentication.js) had high cyclomatic complexity due to deeply nested strategy registration and callback handlers.

## What Changed
- Extracted local login strategy setup into a dedicated helper.
- Extracted SSO strategy loading into a dedicated helper with error handling.
- Extracted strategy auth route registration into a dedicated helper.
- Extracted callback state validation into a dedicated helper.
- Extracted strategy callback authentication flow into a dedicated helper.
- Extracted successful login finalization into a dedicated helper.
- Extracted base auth route registration for register/login/logout endpoints into a dedicated helper.
- Reduced `reloadRoutes` to orchestration logic while preserving existing behavior.

## Why This Helps
- Lowers complexity in `reloadRoutes` and improves maintainability.
- Makes the authentication flow easier to read and reason about.
- Keeps behavior centralized but split into focused units.

## Validation
- Ran `npm run test`
- Result: `4650 passing`, `146 pending`
- Coverage summary generated successfully

## Notes
- No intended functional behavior changes, only structural refactoring to reduce complexity and improve readability.