### PR TITLE
Fixed code smell in src/posts/topics.js: Function with many parameters (count = 5): getPostsFromSet

### DIFF
--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 const topics = require('../topics');
@@ -6,7 +5,7 @@ const user = require('../user');
 const utils = require('../utils');
 
 module.exports = function (Posts) {
-	Posts.getPostsFromSet = async function (set, start, stop, uid, reverse) {
+	Posts.getPostsFromSet = async function ({ set, start, stop, uid, reverse }) {
 		const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
 		const posts = await Posts.getPostsByPids(pids, uid);
 		return await user.blocks.filter(uid, posts);

--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -6,7 +6,7 @@ const user = require('../user');
 const utils = require('../utils');
 
 module.exports = function (Posts) {
-	Posts.getPostsFromSet = async function ({ set, start, stop, uid, reverse }) {
+	Posts.getPostsFromSet = async function ({ set, start, stop, uid, reverse = false }) {
 		const pids = await Posts.getPidsFromSet(set, start, stop, reverse);
 		const posts = await Posts.getPostsByPids(pids, uid);
 		return await user.blocks.filter(uid, posts);
@@ -44,8 +44,8 @@ module.exports = function (Posts) {
 			const postIndex = utils.isNumber(indices[index]) ? parseInt(indices[index], 10) + 1 : null;
 
 			if (slug && postIndex) {
-				const index = postIndex === 1 ? '' : `/${postIndex}`;
-				return `/topic/${slug}${index}`;
+				const postIndexSuffix = postIndex === 1 ? '' : `/${postIndex}`;
+				return `/topic/${slug}${postIndexSuffix}`;
 			}
 			return null;
 		});

--- a/src/posts/topics.js
+++ b/src/posts/topics.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 const topics = require('../topics');


### PR DESCRIPTION
## Fix Code Smells in topics.js

### Problem

Static analysis (`qlty smells`) flagged two code quality issues in topics.js:

1. **Too many parameters** — `getPostsFromSet` had 5 positional parameters (`set`, `start`, `stop`, `uid`, `reverse`), making call sites fragile and argument order easy to mix up.
2. **Variable shadowing** — Inside `generatePostPaths`, the inner `const index` shadowed the outer `.map()` callback parameter `index`, creating a subtle readability hazard and potential source of confusion.

---

### Solution

1. Refactored `getPostsFromSet` to accept a single destructured options object, reducing the parameter count from 5 to 1 and making call sites self-documenting. Added a safe default of `false` for the optional `reverse` parameter.
2. Renamed the shadowing variable in `generatePostPaths` from `index` to `postIndexSuffix` to eliminate the ambiguity.

---

### Changes Made

**`getPostsFromSet` — parameter refactor:**
```js
// Before
Posts.getPostsFromSet = async function (set, start, stop, uid, reverse) {

// After
Posts.getPostsFromSet = async function ({ set, start, stop, uid, reverse = false }) {
```

**`generatePostPaths` — variable shadowing fix:**
```js
// Before
const index = postIndex === 1 ? '' : `/${postIndex}`;
return `/topic/${slug}${index}`;

// After
const postIndexSuffix = postIndex === 1 ? '' : `/${postIndex}`;
return `/topic/${slug}${postIndexSuffix}`;
```

---

### Files Changed

- topics.js

---

### Implementation Notes

- No callers of `getPostsFromSet` exist in the codebase (confirmed via full repo search), so there are no downstream call sites to update.
- The function body of `getPostsFromSet` is unchanged — destructuring extracts the same named variables, so internal behaviour is identical.
- The `reverse = false` default matches the logical expectation: callers that omit `reverse` get forward (non-reversed) ordering, consistent with the original intent.
- The `generatePostPaths` fix is purely a rename — no logic change.

---

### Testing

- Existing unit tests covering post path generation and set retrieval should continue to pass without modification.
- To manually verify, run:
  ```bash
  npm test -- --grep "posts"
  ```
- No new test cases are required as no logic was changed, only parameter structure and variable naming.