### PR TITLE
task 1B context

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -147,7 +147,7 @@ groupsController.members = async function (req, res, next) {
 	if (isHidden && !isMember && !isAdminOrGlobalMod) {
 		return next();
 	}
-	const users = await user.getUsersFromSet(`group:${groupName}:members`, req.uid, start, stop);
+	const users = await user.getUsersFromSet(`group:${groupName}:members`, req.uid, { start, stop });
 
 	const breadcrumbs = helpers.buildBreadcrumbs([
 		{ text: '[[pages:groups]]', url: '/groups' },

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -180,7 +180,7 @@ usersController.getUsersAndCount = async function (set, uid, start, stop) {
 			});
 			return userData;
 		}
-		return await user.getUsersFromSet(set, uid, start, stop);
+		return await user.getUsersFromSet(set, uid, { start, stop });
 	}
 	const [usersData, count] = await Promise.all([
 		getUsers(),

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -196,7 +196,7 @@ Groups.getOwnersAndMembers = async function (groupName, uid, start, stop) {
 	memberStart = Math.max(0, memberStart);
 	memberStop = Math.max(0, memberStop);
 	async function addMembers(start, stop) {
-		let batch = await user.getUsersFromSet(`group:${groupName}:members`, uid, start, stop);
+		let batch = await user.getUsersFromSet(`group:${groupName}:members`, uid, { start, stop });
 		if (!batch.length) {
 			done = true;
 		}

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -72,7 +72,8 @@ User.getUidsFromSet = async function (set, start, stop) {
 	return await db.getSortedSetRevRange(set, start, stop);
 };
 
-User.getUsersFromSet = async function (set, uid, start, stop) {
+User.getUsersFromSet = async function (set, uid, options = {}) {
+	const { start = 0, stop = -1 } = options;
 	const uids = await User.getUidsFromSet(set, start, stop);
 	return await User.getUsers(uids, uid);
 };


### PR DESCRIPTION
copilot fixed too many parameters smell in src/user/index.js: Done! I've refactored [getUsersFromSet](https://didactic-space-eureka-qv94xgx5gg2xwxx.github.dev/) to use an options object pattern. Now:

Simple calls: [user.getUsersFromSet(set, uid)](https://didactic-space-eureka-qv94xgx5gg2xwxx.github.dev/) (uses defaults: start=0, stop=-1)
Paginated calls: [user.getUsersFromSet(set, uid, { start, stop })](https://didactic-space-eureka-qv94xgx5gg2xwxx.github.dev/)
This eliminates the "too many parameters" code smell by encapsulating pagination options into a single object parameter, making the function signature cleaner and more extensible. All three call sites have been updated to use the new syntax.