### PR TITLE
Fix: solving the qlty smell issue in test/post.js

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -228,9 +228,12 @@ describe('Post\'s', () => {
 			assert.strictEqual(score, -1);
 		});
 
-		it('should prevent downvoting more than total daily limit', async () => {
-			const oldValue = meta.config.downvotesPerDay;
-			meta.config.downvotesPerDay = 1;
+		const assertDownvoteLimitError = async ({
+			configKey,
+			expectedMessage,
+		}) => {
+			const oldValue = meta.config[configKey];
+			meta.config[configKey] = 1;
 			let err;
 			const p1 = await topics.reply({
 				uid: voteeUid,
@@ -241,27 +244,25 @@ describe('Post\'s', () => {
 				await apiPosts.downvote({ uid: voterUid }, { pid: p1.pid, room_id: 'topic_1' });
 			} catch (_err) {
 				err = _err;
+			} finally {
+				meta.config[configKey] = oldValue;
 			}
-			assert.equal(err.message, '[[error:too-many-downvotes-today, 1]]');
-			meta.config.downvotesPerDay = oldValue;
+
+			assert.equal(err.message, expectedMessage);
+		};
+
+		it('should prevent downvoting more than total daily limit', async () => {
+			await assertDownvoteLimitError({
+				configKey: 'downvotesPerDay',
+				expectedMessage: '[[error:too-many-downvotes-today, 1]]',
+			});
 		});
 
 		it('should prevent downvoting target user more than total daily limit', async () => {
-			const oldValue = meta.config.downvotesPerUserPerDay;
-			meta.config.downvotesPerUserPerDay = 1;
-			let err;
-			const p1 = await topics.reply({
-				uid: voteeUid,
-				tid: topicData.tid,
-				content: 'raw content',
+			await assertDownvoteLimitError({
+				configKey: 'downvotesPerUserPerDay',
+				expectedMessage: '[[error:too-many-downvotes-today-user, 1]]',
 			});
-			try {
-				await apiPosts.downvote({ uid: voterUid }, { pid: p1.pid, room_id: 'topic_1' });
-			} catch (_err) {
-				err = _err;
-			}
-			assert.equal(err.message, '[[error:too-many-downvotes-today-user, 1]]');
-			meta.config.downvotesPerUserPerDay = oldValue;
 		});
 	});
 


### PR DESCRIPTION
## Summary

This PR removes duplicated test logic in [test/posts.js](test/posts.js) by extracting the shared downvote-limit test flow into a reusable helper.

## Changes

- Refactored the repeated setup and assertion logic used by the two downvote-limit tests
- Replaced the inline duplicated blocks with calls to a shared helper
- Kept the original assertions and test coverage intact

## Why

The two tests for:
- total daily downvote limit
- per-user daily downvote limit

used nearly identical code, which triggered a duplicate-code quality smell. Consolidating that logic improves maintainability and reduces the risk of the tests diverging in the future.

## Impact

- No production code changes
- No intended behavioral changes
- Test-only cleanup to improve code quality

## Validation

- Verified the refactored test file had no static diagnostics after the change